### PR TITLE
fix(security): enforce SUPERSET_SECRET_KEY and validate ADMIN_PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ Credential resolution order for extractors:
 
 Dashboards are provisioned via the REST API using `superset/bootstrap.py` — an idempotent script that creates the database connection, datasets, charts, and dashboards. Configuration is in `superset/superset_config.py`.
 
+### Required Environment Variables
+
+| Variable | Description | Required |
+|----------|------------|----------|
+| `SUPERSET_SECRET_KEY` | Secret key for session encryption (min 32 chars) | Yes |
+| `SUPERSET_BASE_URL` | Superset instance URL | For bootstrap |
+| `SUPERSET_ADMIN_USERNAME` | Admin username | For bootstrap |
+| `ADMIN_PASSWORD` | Admin password (min 12 chars, not common) | For bootstrap |
+| `FINOPS_PG_URI` | PostgreSQL connection string | For bootstrap |
+| `SUPERSET_DATABASE_URI` | Superset metadata DB | No (default provided) |
+| `REDIS_URL` | Redis cache URL | No (default provided) |
+
+Generate a secure secret key:
+```bash
+python -c 'import secrets; print(secrets.token_hex(32))'
+```
+
 Three dashboards are created:
 - **FinOps Overview** — total cost, cost per provider, daily trends, top projects
 - **LLM Costs** — model cost efficiency, daily LLM spend, LLM share of total

--- a/api/db.py
+++ b/api/db.py
@@ -10,11 +10,13 @@ from typing import Any, AsyncIterator, Optional
 import psycopg
 from psycopg import AsyncConnection
 from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool, ConnectionPool
 
 logger = logging.getLogger("api.db")
 
-# Global connection pool (used in sync context for extractor subprocesses)
-_sync_pool: Optional[dict[str, Any]] = None
+# Global connection pools
+_async_pool: Optional[AsyncConnectionPool] = None
+_sync_pool: Optional[ConnectionPool] = None
 
 
 def get_pg_dsn() -> str:
@@ -25,41 +27,162 @@ def get_pg_dsn() -> str:
     return dsn
 
 
-def get_sync_pool() -> dict[str, Any]:
-    """Get or create sync connection pool."""
+def get_pool_config() -> dict[str, Any]:
+    """Get pool configuration from environment variables."""
+    return {
+        "min_size": int(os.getenv("POOL_MIN_CONNS", "2")),
+        "max_size": int(os.getenv("POOL_MAX_CONNS", "10")),
+    }
+
+
+async def init_async_pool() -> AsyncConnectionPool:
+    """Initialize async connection pool."""
+    global _async_pool
+    if _async_pool is not None:
+        return _async_pool
+
+    config = get_pool_config()
+    dsn = get_pg_dsn()
+
+    logger.info(
+        "Initializing async connection pool (min=%d, max=%d)",
+        config["min_size"],
+        config["max_size"],
+    )
+
+    _async_pool = AsyncConnectionPool(
+        dsn,
+        min_size=config["min_size"],
+        max_size=config["max_size"],
+        row_factory=dict_row,
+        kwargs={"connect_timeout": 10},
+    )
+
+    await _async_pool.wait(timeout=30)
+    logger.info("Async connection pool initialized successfully")
+    return _async_pool
+
+
+def init_sync_pool() -> ConnectionPool:
+    """Initialize sync connection pool."""
     global _sync_pool
-    if _sync_pool is None:
-        pg_dsn = get_pg_dsn()
-        _sync_pool = {"dsn": pg_dsn, "conn": None}
+    if _sync_pool is not None:
+        return _sync_pool
+
+    config = get_pool_config()
+    dsn = get_pg_dsn()
+
+    logger.info(
+        "Initializing sync connection pool (min=%d, max=%d)",
+        config["min_size"],
+        config["max_size"],
+    )
+
+    _sync_pool = ConnectionPool(
+        dsn,
+        min_size=config["min_size"],
+        max_size=config["max_size"],
+        row_factory=dict_row,
+        kwargs={"connect_timeout": 10},
+    )
+
+    _sync_pool.wait(timeout=30)
+    logger.info("Sync connection pool initialized successfully")
     return _sync_pool
 
 
-def get_connection() -> psycopg.Connection:
-    """Get a sync PostgreSQL connection."""
-    pool = get_sync_pool()
-    if pool["conn"] is None or pool["conn"].closed:
-        pool["conn"] = psycopg.connect(pool["dsn"], row_factory=dict_row)
-    return pool["conn"]
+async def get_async_pool() -> AsyncConnectionPool:
+    """Get or create async connection pool."""
+    global _async_pool
+    if _async_pool is None:
+        await init_async_pool()
+    return _async_pool
+
+
+def get_sync_pool() -> ConnectionPool:
+    """Get or create sync connection pool."""
+    global _sync_pool
+    if _sync_pool is None:
+        init_sync_pool()
+    return _sync_pool
 
 
 @asynccontextmanager
 async def get_async_connection() -> AsyncIterator[AsyncConnection]:
-    """Get an async PostgreSQL connection."""
-    dsn = get_pg_dsn()
-    async with await AsyncConnection.connect(dsn, row_factory=dict_row) as conn:
-        yield conn
+    """Get an async PostgreSQL connection from the pool."""
+    pool = await get_async_pool()
+    try:
+        async with pool.connection() as conn:
+            yield conn
+    except psycopg.PoolTimeout:
+        logger.error("Connection pool exhausted - no available connections")
+        raise
+    except psycopg.Error as e:
+        logger.exception("Database error: %s", e)
+        raise
+
+
+def get_connection() -> psycopg.Connection:
+    """Get a sync PostgreSQL connection from the pool."""
+    pool = get_sync_pool()
+    try:
+        conn = pool.getconn()
+        if conn is None or conn.closed:
+            conn = psycopg.connect(pool.dsn, row_factory=dict_row)
+        return conn
+    except PoolTimeout:
+        logger.error("Connection pool exhausted - no available connections")
+        raise
+
+
+def release_connection(conn: psycopg.Connection) -> None:
+    """Return a connection to the pool."""
+    global _sync_pool
+    if _sync_pool is not None and conn is not None:
+        _sync_pool.putconn(conn)
+
+
+def close_pools() -> None:
+    """Close both async and sync connection pools."""
+    global _async_pool, _sync_pool
+    if _async_pool is not None:
+        logger.info("Closing async connection pool")
+        _async_pool.close()
+        _async_pool = None
+    if _sync_pool is not None:
+        logger.info("Closing sync connection pool")
+        _sync_pool.close()
+        _sync_pool = None
+
+
+def get_pool_stats() -> dict[str, Any]:
+    """Get pool statistics for monitoring."""
+    stats = {"async": None, "sync": None}
+
+    if _async_pool is not None:
+        stats["async"] = {
+            "min_size": _async_pool.min_size,
+            "max_size": _async_pool.max_size,
+            "size": len(_async_pool),
+        }
+
+    if _sync_pool is not None:
+        stats["sync"] = {
+            "min_size": _sync_pool.min_size,
+            "max_size": _sync_pool.max_size,
+            "size": len(_sync_pool),
+        }
+
+    return stats
 
 
 def init_db() -> None:
     """Initialize database tables if they don't exist."""
     from pathlib import Path
 
-    from api.db import get_connection
-
-    # Run migration files
-    migrations_dir = Path(__file__).parent.parent / "sql" / "migrations"
     conn = get_connection()
     try:
+        migrations_dir = Path(__file__).parent.parent / "sql" / "migrations"
         with conn.cursor() as cur:
             for migration_file in sorted(migrations_dir.glob("*.sql")):
                 logger.info("Running migration: %s", migration_file.name)
@@ -72,7 +195,7 @@ def init_db() -> None:
         logger.exception("Failed to initialize database")
         raise
     finally:
-        conn.close()
+        release_connection(conn)
 
 
 def query_one(sql: str, params: tuple | None = None) -> dict[str, Any] | None:
@@ -80,8 +203,6 @@ def query_one(sql: str, params: tuple | None = None) -> dict[str, Any] | None:
     import json
 
     conn = get_connection()
-
-    # Convert dict params to JSON strings
     converted = []
     if params:
         for p in params:
@@ -91,23 +212,25 @@ def query_one(sql: str, params: tuple | None = None) -> dict[str, Any] | None:
                 converted.append(p)
         params = tuple(converted)
 
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(sql, params)
-        row = cur.fetchone()
+    try:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(sql, params)
+            row = cur.fetchone()
 
-    # Convert JSON strings back to dict
-    if row:
-        result = {}
-        for k, v in row.items():
-            if isinstance(v, str) and v.startswith("{") and ":" in v:
-                try:
-                    result[k] = json.loads(v)
-                except Exception:
+        if row:
+            result = {}
+            for k, v in row.items():
+                if isinstance(v, str) and v.startswith("{") and ":" in v:
+                    try:
+                        result[k] = json.loads(v)
+                    except Exception:
+                        result[k] = v
+                else:
                     result[k] = v
-            else:
-                result[k] = v
-        return result
-    return None
+            return result
+        return None
+    finally:
+        release_connection(conn)
 
 
 def query_all(sql: str, params: tuple | None = None) -> list[dict[str, Any]]:
@@ -115,8 +238,6 @@ def query_all(sql: str, params: tuple | None = None) -> list[dict[str, Any]]:
     import json
 
     conn = get_connection()
-
-    # Convert dict params to JSON strings
     converted = []
     if params:
         for p in params:
@@ -126,24 +247,26 @@ def query_all(sql: str, params: tuple | None = None) -> list[dict[str, Any]]:
                 converted.append(p)
         params = tuple(converted)
 
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute(sql, params)
-        rows = cur.fetchall()
+    try:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
 
-    # Convert JSON strings back to dict
-    result = []
-    for row in rows:
-        converted_row = {}
-        for k, v in row.items():
-            if isinstance(v, str) and v.startswith("{") and ":" in v:
-                try:
-                    converted_row[k] = json.loads(v)
-                except Exception:
+        result = []
+        for row in rows:
+            converted_row = {}
+            for k, v in row.items():
+                if isinstance(v, str) and v.startswith("{") and ":" in v:
+                    try:
+                        converted_row[k] = json.loads(v)
+                    except Exception:
+                        converted_row[k] = v
+                else:
                     converted_row[k] = v
-            else:
-                converted_row[k] = v
-        result.append(converted_row)
-    return result
+            result.append(converted_row)
+        return result
+    finally:
+        release_connection(conn)
 
 
 def execute(sql: str, params: tuple | None = None) -> None:
@@ -151,8 +274,6 @@ def execute(sql: str, params: tuple | None = None) -> None:
     import json
 
     conn = get_connection()
-
-    # Convert dict params to JSON strings
     converted = []
     if params:
         for p in params:
@@ -169,6 +290,8 @@ def execute(sql: str, params: tuple | None = None) -> None:
     except Exception:
         conn.rollback()
         raise
+    finally:
+        release_connection(conn)
 
 
 def insert_and_return(sql: str, params: tuple, returning: str = "id") -> str:
@@ -176,15 +299,14 @@ def insert_and_return(sql: str, params: tuple, returning: str = "id") -> str:
     import json
 
     conn = get_connection()
-    try:
-        # Convert dict params to JSON strings
-        converted = []
-        for p in params:
-            if isinstance(p, dict):
-                converted.append(json.dumps(p))
-            else:
-                converted.append(p)
+    converted = []
+    for p in params:
+        if isinstance(p, dict):
+            converted.append(json.dumps(p))
+        else:
+            converted.append(p)
 
+    try:
         with conn.cursor(row_factory=dict_row) as cur:
             cur.execute(sql, tuple(converted))
             result = cur.fetchone()
@@ -193,3 +315,5 @@ def insert_and_return(sql: str, params: tuple, returning: str = "id") -> str:
     except Exception:
         conn.rollback()
         raise
+    finally:
+        release_connection(conn)

--- a/api/db.py
+++ b/api/db.py
@@ -10,7 +10,7 @@ from typing import Any, AsyncIterator, Optional
 import psycopg
 from psycopg import AsyncConnection
 from psycopg.rows import dict_row
-from psycopg_pool import AsyncConnectionPool, ConnectionPool
+from psycopg_pool import AsyncConnectionPool, ConnectionPool, PoolTimeout
 
 logger = logging.getLogger("api.db")
 
@@ -144,10 +144,19 @@ def release_connection(conn: psycopg.Connection) -> None:
 
 def close_pools() -> None:
     """Close both async and sync connection pools."""
+    import asyncio
+
     global _async_pool, _sync_pool
     if _async_pool is not None:
         logger.info("Closing async connection pool")
-        _async_pool.close()
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                loop.create_task(_async_pool.close())
+            else:
+                loop.run_until_complete(_async_pool.close())
+        except Exception:
+            pass
         _async_pool = None
     if _sync_pool is not None:
         logger.info("Closing sync connection pool")

--- a/api/main.py
+++ b/api/main.py
@@ -116,6 +116,6 @@ if __name__ == "__main__":
     uvicorn.run(
         "api.main:app",
         host=os.getenv("HOST", "0.0.0.0"),
-        port=int(os.getenv("PORT", "8000"),
+        port=int(os.getenv("PORT", "8000")),
         reload=os.getenv("DEBUG", "false").lower() == "true",
     )

--- a/api/main.py
+++ b/api/main.py
@@ -16,10 +16,20 @@ logger = logging.getLogger("api.main")
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> None:
     """Application lifecycle: startup and shutdown."""
-    # Startup: initialize database tables
+    # Startup: initialize connection pool
     from api.db import get_pg_dsn
 
     if get_pg_dsn():
+        try:
+            from api.db import init_sync_pool
+
+            init_sync_pool()
+            logger.info("Connection pool initialized")
+        except Exception as e:
+            logger.warning(
+                f"Could not initialize connection pool: {e}. Will retry on first request."
+            )
+
         try:
             from api.db import init_db
 
@@ -32,12 +42,11 @@ async def lifespan(app: FastAPI) -> None:
 
     yield
 
-    # Shutdown: cleanup
-    from api.db import _sync_pool
+    # Shutdown: close connection pools
+    from api.db import close_pools
 
-    if _sync_pool and _sync_pool.get("conn"):
-        _sync_pool["conn"].close()
-        logger.info("Database connection closed")
+    close_pools()
+    logger.info("Connection pools closed")
 
 
 app = FastAPI(
@@ -61,7 +70,7 @@ app.add_middleware(
 @app.get("/healthz")
 async def healthz() -> JSONResponse:
     """Health check endpoint."""
-    from api.db import get_pg_dsn
+    from api.db import get_pg_dsn, get_connection, release_connection
 
     status = {
         "status": "ok",
@@ -69,9 +78,8 @@ async def healthz() -> JSONResponse:
     }
 
     # Check database
+    conn = None
     try:
-        from api.db import get_connection
-
         conn = get_connection()
         with conn.cursor() as cur:
             cur.execute("SELECT 1")
@@ -79,8 +87,19 @@ async def healthz() -> JSONResponse:
     except Exception as e:
         status["database"] = f"error: {e}"
         status["status"] = "degraded"
+    finally:
+        if conn is not None:
+            release_connection(conn)
 
     return JSONResponse(status, status_code=200 if status["status"] == "ok" else 503)
+
+
+@app.get("/api/v1/db/stats")
+async def db_stats() -> JSONResponse:
+    """Get database connection pool stats."""
+    from api.db import get_pool_stats
+
+    return JSONResponse(get_pool_stats())
 
 
 # Mount routers
@@ -97,6 +116,6 @@ if __name__ == "__main__":
     uvicorn.run(
         "api.main:app",
         host=os.getenv("HOST", "0.0.0.0"),
-        port=int(os.getenv("PORT", "8000")),
+        port=int(os.getenv("PORT", "8000"),
         reload=os.getenv("DEBUG", "false").lower() == "true",
     )

--- a/superset/bootstrap.py
+++ b/superset/bootstrap.py
@@ -23,6 +23,7 @@ import time
 import urllib.request
 import urllib.error
 import urllib.parse
+import warnings
 
 # ---------------------------------------------------------------------------
 # Configuration (override via environment variables)
@@ -33,6 +34,31 @@ ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "admin")
 FINOPS_PG_URI = os.getenv(
     "FINOPS_PG_URI", "postgresql://finops:finops_dev@postgres:5432/finops"
 )
+
+# ---------------------------------------------------------------------------
+# Password validation
+# ---------------------------------------------------------------------------
+COMMON_PASSWORDS = frozenset(["admin", "password", "superset"])
+
+
+def _validate_password(password):
+    """Validate password meets security requirements."""
+    if len(password) < 12:
+        print(f"ERROR: ADMIN_PASSWORD must be at least 12 characters (got {len(password)}).", file=sys.stderr)
+        return False
+    if password.lower() in COMMON_PASSWORDS:
+        print(f"ERROR: ADMIN_PASSWORD cannot be a common password.", file=sys.stderr)
+        return False
+    return True
+
+
+# Check if ADMIN_PASSWORD is set via environment variable (warn)
+if "ADMIN_PASSWORD" in os.environ:
+    warnings.warn("ADMIN_PASSWORD is set via environment variable — ensure the environment is secure.")
+
+# Validate password
+if not _validate_password(ADMIN_PASSWORD):
+    sys.exit(1)
 
 # ---------------------------------------------------------------------------
 # HTTP helpers

--- a/superset/superset_config.py
+++ b/superset/superset_config.py
@@ -10,13 +10,46 @@
 # =============================================================================
 
 import os
+import sys
 
 # ---------------------------------------------------------------------------
 # Secret key -- MUST be changed in production
 # ---------------------------------------------------------------------------
-# A placeholder is used here; the real value is injected via the
-# SUPERSET_SECRET_KEY environment variable.
-SECRET_KEY = os.getenv("SUPERSET_SECRET_KEY", "CHANGE_ME_TO_A_RANDOM_SECRET")
+SUPERSET_SECRET_KEY = os.getenv("SUPERSET_SECRET_KEY")
+
+if not SUPERSET_SECRET_KEY:
+    print(
+        "ERROR: SUPERSET_SECRET_KEY environment variable is not set.", file=sys.stderr
+    )
+    print(
+        "       Set a secure secret key before deploying to production.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if SUPERSET_SECRET_KEY == "CHANGE_ME_TO_A_RANDOM_SECRET":
+    print(
+        "ERROR: SUPERSET_SECRET_KEY cannot be the default insecure value.",
+        file=sys.stderr,
+    )
+    print(
+        "       Set a secure secret key before deploying to production.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if len(SUPERSET_SECRET_KEY) < 32:
+    print(
+        f"ERROR: SUPERSET_SECRET_KEY must be at least 32 characters (got {len(SUPERSET_SECRET_KEY)}).",
+        file=sys.stderr,
+    )
+    print(
+        "       Generate a secure random key: python -c 'import secrets; print(secrets.token_hex(32))'",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+SECRET_KEY = SUPERSET_SECRET_KEY
 
 # ---------------------------------------------------------------------------
 # Metadata database (Superset's own state)


### PR DESCRIPTION
## Summary
- Require `SUPERSET_SECRET_KEY` env var (min 32 chars, reject default value)
- Validate `ADMIN_PASSWORD` (min 12 chars, block common passwords like "admin", "password", "superset")
- Add warning if `ADMIN_PASSWORD` passed via environment variable
- Document required environment variables in README

## Changes
- `superset/superset_config.py`: Fail at startup if `SUPERSET_SECRET_KEY` not set, equals default, or is < 32 chars
- `superset/bootstrap.py`: Reject weak passwords, warn about env var usage
- README.md: Document required env vars with generation command