### PR TITLE
feat(api): unblock finna-cli issues #52-54

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -29,7 +29,7 @@ prepend_sys_path = .
 
 # version location specification; This defaults to alembic/versions.  When using multiple version
 # directories, initial revisions you want first to apply base versions to head.
-version_locations = %()sourceless:alembic/versions
+version_locations = alembic/versions
 
 # version path separator; As mentioned above, this is the character used to split
 # version_locations. The default within head is should be ok, but this is

--- a/alembic/versions/004_cli_unblock_add_alert_ack_columns_and_extractors_.py
+++ b/alembic/versions/004_cli_unblock_add_alert_ack_columns_and_extractors_.py
@@ -1,0 +1,50 @@
+"""add alert ack columns and extractors registry
+
+Revision ID: 004_cli_unblock
+Revises: 003_enriched_schema
+Create Date: 2026-04-24 09:44:46.989395
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "004_cli_unblock"
+down_revision: Union[str, Sequence[str], None] = "003_enriched_schema"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add ack columns to alerts
+    op.execute("""
+        ALTER TABLE alerts
+        ADD COLUMN IF NOT EXISTS acknowledged_at TIMESTAMPTZ,
+        ADD COLUMN IF NOT EXISTS acknowledged_by TEXT
+    """)
+
+    # Create extractors registry table
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS extractors_registry (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            config_id TEXT REFERENCES cloud_config(id) ON DELETE SET NULL,
+            enabled BOOLEAN NOT NULL DEFAULT true,
+            schedule TEXT DEFAULT '0 0 * * *',
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+
+    # Create index for common lookups
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_extractors_registry_provider
+        ON extractors_registry (provider)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS extractors_registry CASCADE")
+    op.execute("ALTER TABLE alerts DROP COLUMN IF EXISTS acknowledged_by")
+    op.execute("ALTER TABLE alerts DROP COLUMN IF EXISTS acknowledged_at")

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -210,13 +210,15 @@ async def db_stats() -> JSONResponse:
 
 
 # Mount routers
-from .routes import auth, config, extractors, costs, alerts  # noqa: E402
+from .routes import auth, config, extractors, costs, alerts, db_dev, extractors_registry  # noqa: E402
 
 app.include_router(config.router, prefix="/api/v1", tags=["config"])
 app.include_router(extractors.router, prefix="/api/v1", tags=["extractors"])
+app.include_router(extractors_registry.router, prefix="/api/v1", tags=["extractors"])
 app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
 app.include_router(costs.router, prefix="/api/v1", tags=["costs"])
 app.include_router(alerts.router, prefix="/api/v1", tags=["alerts"])
+app.include_router(db_dev.router, prefix="/api/v1", tags=["db"])
 
 
 # Initialize Prometheus metrics instrumentator (must be after middleware)

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,5 +1,6 @@
 """Route exports."""
 
-from . import auth, config, extractors, costs, alerts  # noqa: E402
+from . import auth, config, costs, alerts, db_dev  # noqa: E402
+from . import extractors, extractors_registry  # noqa: E402
 
-__all__ = ["auth", "config", "extractors", "costs", "alerts"]
+__all__ = ["auth", "config", "extractors", "extractors_registry", "costs", "alerts", "db_dev"]

--- a/backend/app/api/routes/alerts.py
+++ b/backend/app/api/routes/alerts.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from .. import auth as auth_module
 require_auth = auth_module.require_auth
-from ..db import query_all
+get_current_user = auth_module.get_current_user
+from ..db import query_all, query_one
 
 router = APIRouter()
 
@@ -45,12 +46,47 @@ async def get_alert_stats() -> dict[str, Any]:
 
 
 @router.get("/alerts/active", dependencies=[Depends(require_auth)])
-async def get_active_alerts() -> dict[str, Any]:
+async def get_active_alerts(
+    user: dict[str, Any] = Depends(require_auth),
+) -> dict[str, Any]:
     """Get active firing alerts."""
     sql = """
     SELECT * FROM alerts
-    WHERE status = 'firing'
+    WHERE status = 'firing' AND acknowledged_at IS NULL
     ORDER BY created_at DESC
     """
     rows = query_all(sql)
     return {"alerts": rows, "count": len(rows)}
+
+
+@router.post("/alerts/{alert_id}/acknowledge", dependencies=[Depends(require_auth)])
+async def acknowledge_alert(
+    alert_id: str,
+    user: dict[str, Any] = Depends(require_auth),
+) -> dict[str, Any]:
+    """Acknowledge a single alert."""
+    sql = """
+    UPDATE alerts
+    SET acknowledged_at = now(), acknowledged_by = %s
+    WHERE id = %s AND acknowledged_at IS NULL
+    RETURNING id
+    """
+    row = query_one(sql, (user.get("username", "unknown"), alert_id))
+    if not row:
+        raise HTTPException(status_code=404, detail="Alert not found or already acknowledged")
+    return {"id": alert_id, "acknowledged": True}
+
+
+@router.post("/alerts/acknowledge-all", dependencies=[Depends(require_auth)])
+async def acknowledge_all_alerts(
+    user: dict[str, Any] = Depends(require_auth),
+) -> dict[str, Any]:
+    """Bulk acknowledge all firing alerts."""
+    sql = """
+    UPDATE alerts
+    SET acknowledged_at = now(), acknowledged_by = %s
+    WHERE status = 'firing' AND acknowledged_at IS NULL
+    RETURNING id
+    """
+    rows = query_all(sql, (user.get("username", "unknown"),))
+    return {"acknowledged_count": len(rows), "ids": [r["id"] for r in rows]}

--- a/backend/app/api/routes/db_dev.py
+++ b/backend/app/api/routes/db_dev.py
@@ -1,0 +1,86 @@
+"""Developer-only raw query endpoints for CLI testing."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from .. import auth as auth_module
+require_auth = auth_module.require_auth
+from ..db import query_all
+
+router = APIRouter()
+
+_MAX_LIMIT = 1000
+
+
+def _safely_limit(limit: int) -> int:
+    return min(max(limit, 1), _MAX_LIMIT)
+
+
+@router.get("/db/costs", dependencies=[Depends(require_auth)])
+async def db_costs(
+    limit: int = Query(50, le=_MAX_LIMIT),
+) -> dict[str, Any]:
+    """Raw cost_records rows (dev only)."""
+    sql = """
+    SELECT record_id AS id, provider, service_category, cost_usd AS cost,
+           currency_original AS currency, usage_start::text AS start_date,
+           usage_end::text AS end_date, region
+    FROM cost_records
+    ORDER BY ingestion_ts DESC
+    LIMIT %s
+    """
+    rows = query_all(sql, (_safely_limit(limit),))
+    return {"data": rows, "count": len(rows)}
+
+
+@router.get("/db/alerts", dependencies=[Depends(require_auth)])
+async def db_alerts(
+    limit: int = Query(50, le=_MAX_LIMIT),
+) -> dict[str, Any]:
+    """Raw alerts rows (dev only)."""
+    sql = """
+    SELECT id, type, severity, title, body, status,
+           created_at::text AS first_seen, acknowledged_at::text,
+           acknowledged_by
+    FROM alerts
+    ORDER BY created_at DESC
+    LIMIT %s
+    """
+    rows = query_all(sql, (_safely_limit(limit),))
+    return {"data": rows, "count": len(rows)}
+
+
+@router.get("/db/configs", dependencies=[Depends(require_auth)])
+async def db_configs(
+    limit: int = Query(50, le=_MAX_LIMIT),
+) -> dict[str, Any]:
+    """Raw cloud_config rows (dev only)."""
+    sql = """
+    SELECT id, provider, name, credential_type, config,
+           created_at::text AS last_updated, updated_at::text
+    FROM cloud_config
+    ORDER BY updated_at DESC
+    LIMIT %s
+    """
+    rows = query_all(sql, (_safely_limit(limit),))
+    return {"data": rows, "count": len(rows)}
+
+
+@router.get("/db/extractors", dependencies=[Depends(require_auth)])
+async def db_extractors(
+    limit: int = Query(50, le=_MAX_LIMIT),
+) -> dict[str, Any]:
+    """Raw extractor_runs rows (dev only)."""
+    sql = """
+    SELECT id, config_id, provider, extractor_type, status,
+           started_at::text, finished_at::text, records_extracted,
+           error_message
+    FROM extractor_runs
+    ORDER BY started_at DESC
+    LIMIT %s
+    """
+    rows = query_all(sql, (_safely_limit(limit),))
+    return {"data": rows, "count": len(rows)}

--- a/backend/app/api/routes/extractors_registry.py
+++ b/backend/app/api/routes/extractors_registry.py
@@ -1,0 +1,151 @@
+"""Extractor registry CRUD + trigger endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from .. import auth as auth_module
+require_auth = auth_module.require_auth
+from ..db import insert_and_return, query_all, query_one, execute
+from ..runner import start_extractor
+
+router = APIRouter()
+
+
+# ─── Registry listing ─────────────────────────────────────────────────────────
+
+@router.get("/extractors", dependencies=[Depends(require_auth)])
+async def list_extractors(
+    provider: Optional[str] = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """List extractor registry entries."""
+    sql = """
+    SELECT e.id, e.name, e.provider, e.config_id, e.enabled,
+           e.schedule, e.created_at, e.updated_at,
+           c.name AS config_name
+    FROM extractors_registry e
+    LEFT JOIN cloud_config c ON c.id = e.config_id
+    WHERE (%s::TEXT IS NULL OR e.provider = %s)
+    ORDER BY e.provider, e.name
+    LIMIT %s
+    """
+    rows = query_all(sql, (provider, provider, limit))
+    return {
+        "data": [
+            {
+                "id": r["id"],
+                "name": r["name"],
+                "provider": r["provider"],
+                "config_id": r["config_id"],
+                "config_name": r["config_name"],
+                "enabled": r["enabled"],
+                "schedule": r["schedule"],
+                "created_at": r["created_at"],
+                "updated_at": r["updated_at"],
+            }
+            for r in rows
+        ],
+        "count": len(rows),
+    }
+
+
+# ─── Registry create ──────────────────────────────────────────────────────────
+
+@router.post("/extractors", dependencies=[Depends(require_auth)], status_code=201)
+async def create_extractor(data: dict[str, Any]) -> dict[str, Any]:
+    """Register a new extractor."""
+    name = data.get("name", "")
+    provider = data.get("provider", "")
+    config_id = data.get("config_id")
+    enabled = data.get("enabled", True)
+    schedule = data.get("schedule", "0 0 * * *")
+
+    if not name or not provider:
+        raise HTTPException(status_code=400, detail="name and provider are required")
+
+    eid = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+
+    sql = """
+    INSERT INTO extractors_registry (id, name, provider, config_id, enabled, schedule, created_at, updated_at)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+    RETURNING id
+    """
+    insert_and_return(sql, (eid, name, provider, config_id, enabled, schedule, now, now))
+    return {
+        "id": eid,
+        "name": name,
+        "provider": provider,
+        "config_id": config_id,
+        "enabled": enabled,
+        "schedule": schedule,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+# ─── Registry get ─────────────────────────────────────────────────────────────
+
+@router.get("/extractors/{extractor_id}", dependencies=[Depends(require_auth)])
+async def get_extractor(extractor_id: str) -> dict[str, Any]:
+    """Get a single extractor registry entry."""
+    sql = """
+    SELECT e.id, e.name, e.provider, e.config_id, e.enabled,
+           e.schedule, e.created_at, e.updated_at,
+           c.name AS config_name
+    FROM extractors_registry e
+    LEFT JOIN cloud_config c ON c.id = e.config_id
+    WHERE e.id = %s
+    """
+    row = query_one(sql, (extractor_id,))
+    if not row:
+        raise HTTPException(status_code=404, detail="Extractor not found")
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "provider": row["provider"],
+        "config_id": row["config_id"],
+        "config_name": row["config_name"],
+        "enabled": row["enabled"],
+        "schedule": row["schedule"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+# ─── Registry delete ──────────────────────────────────────────────────────────
+
+@router.delete("/extractors/{extractor_id}", dependencies=[Depends(require_auth)], status_code=204)
+async def delete_extractor(extractor_id: str) -> None:
+    """Remove an extractor from the registry."""
+    execute("DELETE FROM extractors_registry WHERE id = %s", (extractor_id,))
+
+
+# ─── Trigger (delegates to runner) ────────────────────────────────────────────
+
+@router.post("/extractors/{extractor_id}/trigger", dependencies=[Depends(require_auth)])
+async def trigger_extractor(extractor_id: str) -> dict[str, Any]:
+    """Trigger a run for the given extractor registry entry."""
+    row = query_one(
+        "SELECT config_id, provider FROM extractors_registry WHERE id = %s",
+        (extractor_id,),
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Extractor not found")
+
+    config_id = row["config_id"]
+    provider = row["provider"]
+    if not config_id:
+        raise HTTPException(status_code=400, detail="Extractor has no linked config")
+
+    run_id = start_extractor(
+        config_id=config_id,
+        provider=provider,
+        extractor_type=provider,
+    )
+    return {"run_id": run_id, "status": "started"}

--- a/uv.lock
+++ b/uv.lock
@@ -53,6 +53,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
 name = "azure-common"
 version = "1.1.28"
 source = { registry = "https://pypi.org/simple" }
@@ -575,6 +584,9 @@ dependencies = [
     { name = "keyring" },
     { name = "msal" },
     { name = "msal-extensions" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-sdk" },
     { name = "passlib" },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg", extra = ["binary"] },
@@ -616,6 +628,9 @@ requires-dist = [
     { name = "msal", specifier = ">=1.30" },
     { name = "msal-extensions", specifier = ">=1.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20" },
     { name = "passlib", specifier = ">=1.7.4" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
@@ -953,14 +968,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
+    { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -1339,6 +1354,144 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/46/d75a3f8c91915f2e58f61d0a2e4ada63891e7c7a37a20ff7949ba184a6b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0.tar.gz", hash = "sha256:f704201251c6f65772b11bddea1c948000554459101bdbb0116e0a01b70592f6", size = 25754, upload-time = "2026-04-09T14:38:37.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/f6/b09e2e0c9f0b5750cebc6eaf31527b910821453cef40a5a0fe93550422b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0-py3-none-any.whl", hash = "sha256:3a1a86bd24806ccf136ec9737dbfa4c09b069f9130ff66b0acb014f9c5255fd1", size = 20299, upload-time = "2026-04-09T14:38:17.01Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fd/b8e90bb340957f059084376f94cff336b0e871a42feba7d3f7342365e987/opentelemetry_instrumentation-0.62b0.tar.gz", hash = "sha256:aa1b0b9ab2e1722c2a8a5384fb016fc28d30bba51826676c8036074790d2861e", size = 34042, upload-time = "2026-04-09T14:40:22.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b6/3356d2e335e3c449c5183e9b023f30f04f1b7073a6583c68745ea2e704b1/opentelemetry_instrumentation-0.62b0-py3-none-any.whl", hash = "sha256:30d4e76486eae64fb095264a70c2c809c4bed17b73373e53091470661f7d477c", size = 34158, upload-time = "2026-04-09T14:39:21.428Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/38/999bf777774878971c2716de4b7a03cd57a7decb4af25090e703b79fa0e5/opentelemetry_instrumentation_asgi-0.62b0.tar.gz", hash = "sha256:93cde8c62e5918a3c1ff9ba020518127300e5e0816b7e8b14baf46a26ba619fc", size = 26779, upload-time = "2026-04-09T14:40:26.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/cf/29df82f5870178143bdb5c9a7be044b9f78c71e1c5dcf995242e86d80158/opentelemetry_instrumentation_asgi-0.62b0-py3-none-any.whl", hash = "sha256:89b62a6f996b260b162f515c25e6d78e39286e4cbe2f935899e51b32f31027e2", size = 17011, upload-time = "2026-04-09T14:39:27.305Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/09/92740c6d114d1bef392557a03ae6de64065c83c1b331dae9b57fe718497c/opentelemetry_instrumentation_fastapi-0.62b0.tar.gz", hash = "sha256:e4748e4e575077e08beaf2c5d2f369da63dd90882d89d73c4192a97356637dec", size = 25056, upload-time = "2026-04-09T14:40:36.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/bb/186ffe0fde0ad33ceb50e1d3596cc849b732d3b825592a6a507a40c8c49b/opentelemetry_instrumentation_fastapi-0.62b0-py3-none-any.whl", hash = "sha256:06d3272ad15f9daea5a0a27c32831aff376110a4b0394197120256ef6d610e6e", size = 13482, upload-time = "2026-04-09T14:39:43.446Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/e7/830f7c57135158eb8a8efd3f94ab191a89e3b8a49bed314a35ee501da3f2/opentelemetry_util_http-0.62b0.tar.gz", hash = "sha256:a62e4b19b8a432c0de657f167dee3455516136bb9c6ed463ca8063019970d835", size = 11393, upload-time = "2026-04-09T14:40:59.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/7f/5c1b7d4385852b9e5eacd4e7f9d8b565d3d351d17463b24916ad098adf1a/opentelemetry_util_http-0.62b0-py3-none-any.whl", hash = "sha256:c20462808d8cc95b69b0dc4a3e02a9d36beb663347e96c931f51ffd78bd318ad", size = 9294, upload-time = "2026-04-09T14:40:19.014Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR unblocks three finna-cli GitHub issues by adding missing backend endpoints.

## Implementation
### Issue #52 — Alert Acknowledge Endpoints
- Added `acknowledged_at` and `acknowledged_by` columns to `alerts` table (alembic migration 004)
- `POST /api/v1/alerts/{id}/acknowledge` — acknowledge single alert
- `POST /api/v1/alerts/acknowledge-all` — bulk acknowledge all firing alerts
- Auth user injected via `require_auth` dependency

### Issue #53 — Developer /db/* Raw Query Endpoints
- New router `db_dev.py` with four GET endpoints:
  - `GET /api/v1/db/costs?limit=N`
  - `GET /api/v1/db/alerts?limit=N`
  - `GET /api/v1/db/configs?limit=N`
  - `GET /api/v1/db/extractors?limit=N`
- Returns `{data:[], count:N}` for CLI raw fetch
- Protected behind `require_auth`

### Issue #54 — Extractor Registry CRUD
- New router `extractors_registry.py`:
  - `GET /api/v1/extractors` — list registry entries
  - `POST /api/v1/extractors` — create registry entry
  - `GET /api/v1/extractors/{id}` — get entry
  - `DELETE /api/v1/extractors/{id}` — delete entry
  - `POST /api/v1/extractors/{id}/trigger` — trigger run (delegates to runner)
- Existing `/extractors/status`, `/extractors/run/*` routes remain unchanged for backward compatibility
  
## Schema Changes
- Alembic migration `004_cli_unblock` adds:
  - `alerts.acknowledged_at` (TIMESTAMPTZ)
  - `alerts.acknowledged_by` (TEXT)
  - `extractors_registry` table with CRUD fields

Closes #52
Closes #53
Closes #54
