### PR TITLE
feat: Add extractor registry CRUD endpoints

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -210,10 +210,11 @@ async def db_stats() -> JSONResponse:
 
 
 # Mount routers
-from .routes import auth, config, extractors, costs, alerts  # noqa: E402
+from .routes import auth, config, extractors, extractors_crud, costs, alerts  # noqa: E402
 
 app.include_router(config.router, prefix="/api/v1", tags=["config"])
 app.include_router(extractors.router, prefix="/api/v1", tags=["extractors"])
+app.include_router(extractors_crud.router, prefix="/api/v1", tags=["extractors"])
 app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
 app.include_router(costs.router, prefix="/api/v1", tags=["costs"])
 app.include_router(alerts.router, prefix="/api/v1", tags=["alerts"])

--- a/backend/app/api/models.py
+++ b/backend/app/api/models.py
@@ -199,3 +199,69 @@ class ExtractorHealthResponse(BaseModel):
     status: str
     last_run: datetime
     records_count: int = 0
+
+
+# ============================================================================#
+# Extractor Registry schemas                                                  #
+# ============================================================================#
+
+
+class ExtractorCreate(BaseModel):
+    """Request schema for creating an extractor."""
+
+    name: str = Field(..., description="Human-readable name")
+    provider: str = Field(..., description="Cloud provider")
+    extractor_type: str = Field(..., description="Extractor type (e.g., azure_cost, gcp_billing)")
+    enabled: bool = Field(default=True, description="Whether the extractor is enabled")
+    schedule: Optional[str] = Field(None, description="Cron expression for scheduled runs")
+    config_id: Optional[str] = Field(None, description="Cloud config ID to use")
+
+
+class ExtractorUpdate(BaseModel):
+    """Request schema for updating an extractor."""
+
+    name: Optional[str] = None
+    enabled: Optional[bool] = None
+    schedule: Optional[str] = None
+    config_id: Optional[str] = None
+
+
+class ExtractorResponse(BaseModel):
+    """Response schema for extractor."""
+
+    id: str
+    name: str
+    provider: str
+    extractor_type: str
+    enabled: bool
+    schedule: Optional[str]
+    config_id: Optional[str]
+    status: str
+    last_run_id: Optional[str]
+    last_run_at: Optional[datetime]
+    created_at: datetime
+    updated_at: datetime
+
+
+class ExtractorListResponse(BaseModel):
+    """Response schema for extractor list."""
+
+    extractors: list[ExtractorResponse]
+    count: int
+
+
+class ExtractorRunTriggerRequest(BaseModel):
+    """Request schema for triggering an extractor run."""
+
+    config_id: Optional[str] = Field(
+        None,
+        description="Specific config ID to use (defaults to the extractor's config_id)"
+    )
+
+
+class ExtractorRunTriggerResponse(BaseModel):
+    """Response schema for extractor run trigger."""
+
+    run_id: str
+    status: str
+    extractor_id: str

--- a/backend/app/api/routes/extractors.py
+++ b/backend/app/api/routes/extractors.py
@@ -23,18 +23,19 @@ from ..runner import cancel_run, get_run_status, list_runs, start_extractor
 router = APIRouter()
 
 
+# Keep existing extractors/run endpoints for backward compatibility
 @router.get("/extractors/status", dependencies=[Depends(require_auth)])
-async def list_extractors(
+async def list_extractor_runs(
     limit: int = 50, provider: Optional[str] = None
 ) -> dict[str, Any]:
-    """List extractor runs."""
+    """List extractor runs (legacy endpoint)."""
     runs = list_runs(limit=limit, provider=provider)
     return {"runs": runs, "count": len(runs)}
 
 
 @router.post("/extractors/run", dependencies=[Depends(require_auth)])
-async def run_extractor(data: dict[str, Any]) -> dict[str, Any]:
-    """Run an extractor."""
+async def run_extractor_via_post(data: dict[str, Any]) -> dict[str, Any]:
+    """Run an extractor (legacy endpoint)."""
     provider = data.get("provider", "gcp")
     extractor_type = data.get("extractor_type", provider)
     config_id = data.get("config_id")

--- a/backend/app/api/routes/extractors_crud.py
+++ b/backend/app/api/routes/extractors_crud.py
@@ -1,0 +1,243 @@
+"""Extractor registry endpoints - New CRUD operations."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+# Import auth module from parent package
+from .. import auth as auth_module
+require_auth = auth_module.require_auth
+
+from ..models import (
+    ExtractorCreate,
+    ExtractorUpdate,
+    ExtractorResponse,
+    ExtractorListResponse,
+    ExtractorRunTriggerRequest,
+    ExtractorRunTriggerResponse,
+)
+
+router = APIRouter()
+
+
+def _extractor_to_response(extractor: dict[str, Any]) -> ExtractorResponse:
+    """Convert extractor dict to response schema."""
+    return ExtractorResponse(
+        id=extractor["id"],
+        name=extractor["name"],
+        provider=extractor["provider"],
+        extractor_type=extractor["extractor_type"],
+        enabled=extractor["enabled"],
+        schedule=extractor.get("schedule"),
+        config_id=extractor.get("config_id"),
+        status=extractor.get("status", "idle"),
+        last_run_id=extractor.get("last_run_id"),
+        last_run_at=extractor.get("last_run_at"),
+        created_at=extractor["created_at"],
+        updated_at=extractor["updated_at"],
+    )
+
+
+@router.get("/extractors", response_model=ExtractorListResponse, dependencies=[Depends(require_auth)])
+async def list_extractors(
+    provider: str | None = None,
+    enabled: bool | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """List extractors with optional filtering."""
+    from ..db import query_all
+    
+    where_clauses = []
+    params = []
+    
+    if provider:
+        where_clauses.append("provider = %s")
+        params.append(provider)
+    if enabled is not None:
+        where_clauses.append("enabled = %s")
+        params.append(enabled)
+    
+    where_clause = ""
+    if where_clauses:
+        where_clause = "WHERE " + " AND ".join(where_clauses)
+    
+    sql = f"""
+        SELECT id, name, provider, extractor_type, enabled, schedule,
+               config_id, status, last_run_id, last_run_at, created_at, updated_at
+        FROM extractors
+        {where_clause}
+        ORDER BY created_at DESC
+        LIMIT %s
+    """
+    
+    extractors = query_all(sql, params + [limit])
+    
+    return {
+        "extractors": [_extractor_to_response(e) for e in extractors],
+        "count": len(extractors),
+    }
+
+
+@router.get("/extractors/{extractor_id}", response_model=ExtractorResponse, dependencies=[Depends(require_auth)])
+async def get_extractor(extractor_id: str) -> dict[str, Any]:
+    """Get a single extractor by ID."""
+    from ..db import query_one
+    
+    sql = """
+        SELECT id, name, provider, extractor_type, enabled, schedule,
+               config_id, status, last_run_id, last_run_at, created_at, updated_at
+        FROM extractors
+        WHERE id = %s
+    """
+    extractor = query_one(sql, (extractor_id,))
+    
+    if not extractor:
+        raise HTTPException(status_code=404, detail=f"Extractor {extractor_id} not found")
+    
+    return extractor
+
+
+@router.post("/extractors", response_model=ExtractorResponse, dependencies=[Depends(require_auth)])
+async def create_extractor(data: ExtractorCreate) -> dict[str, Any]:
+    """Create a new extractor."""
+    from ..db import insert_and_return, query_one
+    
+    extractor_id = str(uuid.uuid4())[:12]  # Short ID
+    
+    # Validate config_id exists if provided
+    if data.config_id:
+        config = query_one("SELECT id FROM cloud_config WHERE id = %s", (data.config_id,))
+        if not config:
+            raise HTTPException(status_code=400, detail=f"Config {data.config_id} not found")
+    
+    now = datetime.now(timezone.utc)
+    
+    sql = """
+        INSERT INTO extractors (id, name, provider, extractor_type, enabled, schedule, config_id, status, created_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        RETURNING id, name, provider, extractor_type, enabled, schedule, config_id, status, last_run_id, last_run_at, created_at, updated_at
+    """
+    
+    result = insert_and_return(
+        sql,
+        (
+            extractor_id,
+            data.name,
+            data.provider,
+            data.extractor_type,
+            data.enabled,
+            data.schedule,
+            data.config_id,
+            "idle",
+            now,
+        ),
+    )
+    
+    return result
+
+
+@router.put("/extractors/{extractor_id}", response_model=ExtractorResponse, dependencies=[Depends(require_auth)])
+async def update_extractor(extractor_id: str, data: ExtractorUpdate) -> dict[str, Any]:
+    """Update an extractor."""
+    from ..db import query_one, execute
+    
+    extractor = query_one("SELECT * FROM extractors WHERE id = %s", (extractor_id,))
+    if not extractor:
+        raise HTTPException(status_code=404, detail=f"Extractor {extractor_id} not found")
+    
+    # Build update query dynamically
+    updates = []
+    params = []
+    
+    if data.name is not None:
+        updates.append("name = %s")
+        params.append(data.name)
+    if data.enabled is not None:
+        updates.append("enabled = %s")
+        params.append(data.enabled)
+    if data.schedule is not None:
+        updates.append("schedule = %s")
+        params.append(data.schedule)
+    if data.config_id is not None:
+        # Validate config_id if provided
+        if data.config_id:
+            config = query_one("SELECT id FROM cloud_config WHERE id = %s", (data.config_id,))
+            if not config:
+                raise HTTPException(status_code=400, detail=f"Config {data.config_id} not found")
+        updates.append("config_id = %s")
+        params.append(data.config_id)
+    
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+    
+    updates.append("updated_at = now()")
+    params.append(extractor_id)
+    
+    sql = f"""
+        UPDATE extractors
+        SET {", ".join(updates)}
+        WHERE id = %s
+        RETURNING id, name, provider, extractor_type, enabled, schedule, config_id, status, last_run_id, last_run_at, created_at, updated_at
+    """
+    
+    result = query_one(sql, tuple(params))
+    return result
+
+
+@router.delete("/extractors/{extractor_id}", status_code=204, dependencies=[Depends(require_auth)])
+async def delete_extractor(extractor_id: str) -> None:
+    """Delete an extractor."""
+    from ..db import query_one, execute
+    
+    extractor = query_one("SELECT id FROM extractors WHERE id = %s", (extractor_id,))
+    if not extractor:
+        raise HTTPException(status_code=404, detail=f"Extractor {extractor_id} not found")
+    
+    execute("DELETE FROM extractors WHERE id = %s", (extractor_id,))
+
+
+@router.post("/extractors/{extractor_id}/trigger", response_model=ExtractorRunTriggerResponse, dependencies=[Depends(require_auth)])
+async def trigger_extractor_run(extractor_id: str, data: ExtractorRunTriggerRequest | None = None) -> dict[str, Any]:
+    """Trigger a run for an extractor."""
+    from ..db import query_one
+    from ..runner import start_extractor
+    
+    extractor = query_one("SELECT * FROM extractors WHERE id = %s", (extractor_id,))
+    if not extractor:
+        raise HTTPException(status_code=404, detail=f"Extractor {extractor_id} not found")
+    
+    if not extractor["enabled"]:
+        raise HTTPException(status_code=400, detail=f"Extractor {extractor_id} is disabled")
+    
+    # Use provided config_id or the extractor's config_id
+    config_id = data.config_id if data and data.config_id else extractor["config_id"]
+    
+    if not config_id:
+        raise HTTPException(
+            status_code=400,
+            detail=f"No config_id provided and extractor {extractor_id} has no default config_id",
+        )
+    
+    # Start the extractor run
+    run_id = start_extractor(
+        config_id=config_id,
+        provider=extractor["provider"],
+        extractor_type=extractor["extractor_type"],
+    )
+    
+    # Update last_run_id and last_run_at
+    from ..db import execute
+    execute(
+        "UPDATE extractors SET last_run_id = %s, last_run_at = now(), status = 'running' WHERE id = %s",
+        (run_id, extractor_id),
+    )
+    
+    return {
+        "run_id": run_id,
+        "status": "started",
+        "extractor_id": extractor_id,
+    }

--- a/sql/migrations/002_extractors_registry.sql
+++ b/sql/migrations/002_extractors_registry.sql
@@ -1,0 +1,31 @@
+-- Extractors registry table for CRUD operations
+-- This table stores the extractor configurations that can be scheduled and triggered
+
+CREATE TABLE IF NOT EXISTS extractors (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    extractor_type TEXT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    schedule TEXT,  -- Cron expression (optional)
+    config_id TEXT REFERENCES cloud_config(id) ON DELETE SET NULL,
+    status TEXT NOT NULL DEFAULT 'idle',  -- idle, running, paused
+    last_run_id TEXT REFERENCES extractor_runs(id) ON DELETE SET NULL,
+    last_run_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_extractors_provider ON extractors(provider);
+CREATE INDEX IF NOT EXISTS idx_extractors_enabled ON extractors(enabled);
+CREATE INDEX IF NOT EXISTS idx_extractors_status ON extractors(status);
+
+-- Seed some default extractors
+INSERT INTO extractors (id, name, provider, extractor_type, enabled, config_id, schedule)
+VALUES
+    ('ext_azure_cost', 'Azure Cost Extractor', 'azure', 'azure_cost', true, 'c_az_prod', '0 * * * *'),
+    ('ext_gcp_billing', 'GCP Billing Extractor', 'gcp', 'gcp_billing', true, 'c_gcp_prod', '0 * * * *'),
+    ('ext_exchange_rates', 'Exchange Rates', 'ecb', 'exchange_rates', true, NULL, '0 0 * * *'),
+    ('ext_otel_llm_us', 'OTEL LLM (US)', 'llm', 'otel_llm', true, 'c_llm_us', '0 * * * *'),
+    ('ext_otel_llm_eu', 'OTEL LLM (EU)', 'llm', 'otel_llm', true, 'c_llm_eu', '0 * * * *')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

This PR adds a full extractor registry with CRUD operations, addressing issue #54 where CLI endpoints diverged from OpenAPI specs.

## Changes

- **New  endpoints:**
  -  - List extractors with optional filtering
  -  - Create a new extractor
  -  - Get a single extractor
  -  - Update an extractor
  -  - Delete an extractor
  -  - Trigger a run for an extractor

- **Backend changes:**
  - Added  table with schedule, enabled, status fields
  - Added  router with full CRUD operations
  - Updated  to keep legacy  and  endpoints for backward compatibility
  - Updated  with new Extractor schemas
  - Added migration 

- **OpenAPI / CLI alignment:**
  - CLI now expects: GET , POST , GET , POST , DELETE 
  - Backend now provides: GET , POST , GET , PUT , DELETE , POST 
  - Backward compatible: Legacy endpoints  and  still available

## Testing

- [ ] Run  to verify tests
- [ ] Test new endpoints via curl or Postman
- [ ] Run  to verify trigger endpoint

Fixes #54