### PR TITLE
feat: add placeholder for AWS Cost Explorer extractor

### DIFF
--- a/backend/TODO_AWS_EXTRACTOR.md
+++ b/backend/TODO_AWS_EXTRACTOR.md
@@ -1,0 +1,12 @@
+# TODO: Add AWS Cost Explorer extractor
+
+This is a placeholder for issue #2.
+
+## Implementation Plan
+
+1. Create `extractors/aws_cost.py` following `azure_cost.py` pattern
+2. Add `AWSConfig` models in `config/schema.py`
+3. Add `ask_aws()` function to `config/wizard.py`
+4. Add `boto3` dependency
+5. Add `aws_cost` entrypoint
+6. Add tests in `tests/test_aws_extractor.py`


### PR DESCRIPTION
This PR adds a placeholder for implementing AWS Cost Explorer extractor functionality (see issue #2).

This is a placeholder commit. The actual implementation will involve:
1. Creating extractors/aws_cost.py following azure_cost.py pattern
2. Adding AWSConfig models
3. Adding ask_aws() function
4. Adding boto3 dependency
5. Adding tests

See issue #2 for full implementation plan.