### PR TITLE
fix: consolidate release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.EXTRACTOR_IMAGE }}:${{ github.ref_name }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.EXTRACTOR_IMAGE }}:${{ steps.meta.outputs.version }}
           format: sarif
           output: trivy-results.sarif
 


### PR DESCRIPTION
## Summary
- Remove zombie GHCR packages (finops-superset, finops-frontend, finna-app-ui, etc.)
- Delete docker-build.yml (race condition with ci.yml on tags)
- Rewrite ci.yml: main/PR CI only, no tag triggers, no releases
- Create release.yml: single v* tag workflow for both images + Trivy + GitHub Release
- Fix Trivy image tag mismatch (use steps.meta.outputs.version)