### PR TITLE
[SECURITY] Require JWT_SECRET environment variable

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -11,7 +11,9 @@ from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt  # type: ignore[import-untyped]
 
-JWT_SECRET = os.getenv("JWT_SECRET", "default-secret-key-change-in-production")
+JWT_SECRET = os.environ.get("JWT_SECRET")
+if not JWT_SECRET:
+    raise ValueError("JWT_SECRET environment variable is required")
 JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
 JWT_EXPIRATION_MINUTES = int(os.getenv("JWT_EXPIRATION_MINUTES", "60"))
 


### PR DESCRIPTION
## Summary
- Remove hardcoded default JWT secret from 
- Environment variable  is now required at startup
- Fails fast with clear error message if not set

## Testing
- [ ] Verify app fails to start without JWT_SECRET
- [ ] Verify app starts correctly with valid JWT_SECRET

Closes #146