### PR TITLE
[SECURITY] CORS configuration uses explicit origins

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -40,12 +40,13 @@ app = FastAPI(
 register_error_handlers(app)
 
 # Add CORS middleware
+allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:5173,http://localhost:3000").split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # Re-export routes module to avoid circular import issues


### PR DESCRIPTION
Fixes #148 - CORS middleware now uses explicit origins from ALLOWED_ORIGINS environment variable instead of allowing all origins (*). This prevents cross-origin requests from untrusted domains.