### PR TITLE
[frontend] Fix table row key to use stable ID instead of SKU+index combination

### DIFF
--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -65,7 +65,7 @@ export function ProjectDetailPage() {
   useEffect(() => { setNote((p as any)?.note ?? '') }, [(p as any)?.note])
 
   const skus = useMemo(
-    () => costsResp?.costs?.map(c => ({ sku: c.sku, mtd: c.mtd, prev: c.prev ?? 0, delta: c.delta ?? 0 })) ?? [],
+    () => costsResp?.costs?.map(c => ({ id: c.id, sku: c.sku, mtd: c.mtd, prev: c.prev ?? 0, delta: c.delta ?? 0 })) ?? [],
     [costsResp]
   )
 
@@ -234,7 +234,7 @@ export function ProjectDetailPage() {
             </tr></thead>
             <tbody>
               {filteredSkus.map((c, i) => (
-                <tr key={`${c.sku}-${i}`}>
+                <tr key={c.id}>
                   <td className="mono">{c.sku}</td>
                   <td className="num mono">{money(c.mtd)}</td>
                   <td className="num mono muted">{money(c.prev)}</td>


### PR DESCRIPTION
This PR fixes issue #193 by updating the table row key in ProjectDetailPage.tsx to use the stable 'id' field from CostRecord objects instead of combining SKU with array index.

This prevents React reconciliation issues when items are filtered or reordered, which was causing unnecessary DOM node remounting and local state resets.

Fixes #193