### PR TITLE
fix(api): return 503 when DB pool is unavailable (#167)

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -52,6 +52,13 @@ app.add_middleware(
 # Re-export routes module to avoid circular import issues
 __all__ = ["app", "auth", "db", "routes"]
 
+# DB middleware imports
+import logging
+import psycopg
+from psycopg_pool import PoolTimeout
+
+_logger = logging.getLogger("api.main")
+
 
 @app.middleware("http")
 async def db_session_middleware(request: Request, call_next: Any) -> Any:
@@ -61,15 +68,13 @@ async def db_session_middleware(request: Request, call_next: Any) -> Any:
     try:
         async with db.get_async_connection() as conn:
             request.state.db = conn
-            response = await call_next(request)
-        return response
-    except Exception as exc:
-        # Log the error but still process the request — avoids breaking responses
-        # when DB connection issues occur. In production, consider a circuit breaker.
-        import logging
-        logging.getLogger("api.main").warning("DB middleware error: %s", exc)
-        response = await call_next(request)
-        return response
+            return await call_next(request)
+    except (psycopg.OperationalError, PoolTimeout) as exc:
+        # DB unavailable (pool exhausted or DB down) — return 503 immediately
+        _logger.error("DB unavailable: %s", exc)
+        return JSONResponse(
+            status_code=503, content={"detail": "database_unavailable"}
+        )
 
 
 # Health check endpoints


### PR DESCRIPTION
Closes #167.

On DB acquisition failure the middleware logged a warning then called `call_next` again with `request.state.db` unset — so handlers blew up with AttributeError/None and masked the real cause.

Behavior now:
- `OperationalError` / `PoolTimeout` during acquisition → `503 database_unavailable`.
- Exceptions raised inside `call_next` propagate normally so FastAPI's exception handlers work.

Adjust the caught exception list if the actual exception types in db.py differ from what I selected.