### PR TITLE
fix(extractors): GCP batch reports real insert count (#182)

### DIFF
--- a/extractors/gcp_billing.py
+++ b/extractors/gcp_billing.py
@@ -223,7 +223,8 @@ _INSERT_SQL = SQL(
     "cost_usd, currency_original, cost_original, discount_usd, net_cost_usd, "
     "usage_quantity, usage_unit, tags) "
     "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
-    "ON CONFLICT (record_id) DO NOTHING"
+    "ON CONFLICT (record_id) DO NOTHING "
+    "RETURNING record_id"
 )
 
 
@@ -277,14 +278,19 @@ def _batch_insert(
     ]
 
     with conn.cursor() as cur:
-        cur.executemany(_INSERT_SQL, rows)
+        cur.executemany(_INSERT_SQL, rows, returning=True)
+        actually_inserted = sum(1 for _ in cur)
     conn.commit()
 
-    inserted = len(
-        records
-    )  # ON CONFLICT DO NOTHING doesn't give rowcount via executemany
-    logger.debug("Batch inserted up to %d records", inserted)
-    return inserted
+    attempted = len(records)
+    skipped = attempted - actually_inserted
+    logger.info(
+        "Batch inserted: attempted=%d inserted=%d skipped=%d",
+        attempted,
+        actually_inserted,
+        skipped,
+    )
+    return actually_inserted
 
 
 # ---------------------------------------------------------------------------

--- a/extractors/gcp_billing.py
+++ b/extractors/gcp_billing.py
@@ -279,7 +279,11 @@ def _batch_insert(
 
     with conn.cursor() as cur:
         cur.executemany(_INSERT_SQL, rows, returning=True)
-        actually_inserted = sum(1 for _ in cur)
+        actually_inserted = 0
+        while True:
+            actually_inserted += sum(1 for _ in cur)
+            if not cur.nextset():
+                break
     conn.commit()
 
     attempted = len(records)


### PR DESCRIPTION
Closes #182.

`executemany` + `ON CONFLICT DO NOTHING` does not give a usable rowcount, so the old code returned `len(records)` and overstated ingestion volume — a run that fetched 1000 already-seen rows reported '1000 inserted'.

Now uses psycopg v3's `executemany(..., returning=True)` with `RETURNING record_id` and counts rows actually written. Logs both attempted and inserted at INFO level, enabling accurate health metrics and dashboards.

Changes:
- Added `RETURNING record_id` to the INSERT SQL statement
- Updated `_batch_insert()` to use `returning=True` flag on `executemany()`
- Iterate the cursor to count actual inserts: `sum(1 for _ in cur)`
- Log attempted, inserted, and skipped counts for observability

Validation: psycopg v3.1+ is pinned in pyproject.toml, so `executemany(..., returning=True)` with cursor iteration is supported.