### PR TITLE
fix(api): remove unused token_verification_middleware (#168)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -145,28 +145,10 @@ async def require_admin(user: dict[str, Any] = Depends(get_current_user)) -> dic
     return user
 
 
-async def token_verification_middleware(request: Request, call_next):
-    """Middleware to verify JWT token on all protected routes."""
-    if request.url.path.startswith("/api/v1/") and request.url.path != "/api/v1/auth/token":
-        auth_header = request.headers.get("Authorization")
-        if auth_header and auth_header.startswith("Bearer "):
-            token = auth_header.split(" ")[1]
-            try:
-                decode_token(token)
-            except HTTPException:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid or expired token",
-                    headers={"WWW-Authenticate": "Bearer"},
-                )
-        else:
-            if request.url.path != "/api/v1/healthz":
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Not authenticated",
-                    headers={"WWW-Authenticate": "Bearer"},
-                )
-    return await call_next(request)
+# JWT verification is enforced per-route via FastAPI dependencies
+# (Depends(require_auth), Depends(require_admin)). Public routes
+# (/auth/oidc/providers, /auth/github, /healthz) intentionally have
+# no auth dependency. See routes/*.py for usage.
 
 
 def get_github_redirect_url() -> str | None:


### PR DESCRIPTION
Closes #168.

`token_verification_middleware` in `backend/app/api/auth.py` was defined but never registered with `app.add_middleware()`. Verified by:

```
$ grep -rn token_verification_middleware backend/
backend/app/api/auth.py:148:async def token_verification_middleware(...)
```

Only the definition exists. No call site. Auth was already enforced per-route via `Depends(require_auth)` / `Depends(require_admin)` everywhere it matters, so removal closes a false-sense-of-security branch.

Replaces 22 lines of dead code with a 4-line comment documenting the real auth pattern.

Supersedes #210 which bundled this fix with unrelated OIDC / UI / alembic changes.