### PR TITLE
feat: OIDC device authorization flow for CLI login (RFC 8628)

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -199,6 +199,7 @@ from .routes import (  # noqa: E402
     costs,
     extractors_registry,
     oidc_auth,
+    oidc_device_auth,
     wastage,
 )
 
@@ -207,6 +208,7 @@ app.include_router(extractors_registry.router, prefix="/api/v1", tags=["extracto
 app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
 app.include_router(auth_providers.router, prefix="/api/v1", tags=["auth"])
 app.include_router(oidc_auth.router, prefix="/api/v1", tags=["auth"])
+app.include_router(oidc_device_auth.router, prefix="/api/v1", tags=["auth"])
 app.include_router(costs.router, prefix="/api/v1", tags=["costs"])
 app.include_router(alerts.router, prefix="/api/v1", tags=["alerts"])
 app.include_router(wastage.router, prefix="/api/v1", tags=["wastage"])

--- a/backend/app/api/models.py
+++ b/backend/app/api/models.py
@@ -177,6 +177,45 @@ class DeviceCodePollResponse(BaseModel):
 
 
 # ============================================================================
+# OIDC Device Authorization Grant schemas (RFC 8628)
+# ============================================================================
+
+
+class OIDCDeviceStartRequest(BaseModel):
+    """Request to initiate OIDC device authorization flow."""
+
+    provider_id: str = Field(..., description="OIDC provider UUID")
+
+
+class OIDCDeviceStartResponse(BaseModel):
+    """Response from initiating OIDC device authorization flow."""
+
+    device_code: str = Field(..., description="Device code to exchange for tokens")
+    user_code: str = Field(..., description="User-facing code to enter in browser")
+    verification_uri: str = Field(..., description="URL the user should open")
+    verification_uri_complete: str | None = Field(
+        None, description="URL with user_code pre-filled (if supported)"
+    )
+    expires_in: int = Field(..., description="Seconds until device code expires")
+    interval: int = Field(default=5, description="Seconds between polling attempts")
+
+
+class OIDCDevicePollRequest(BaseModel):
+    """Request to poll/exchange a device code for tokens."""
+
+    device_code: str = Field(..., description="Device code from start response")
+
+
+class OIDCDevicePollResponse(BaseModel):
+    """Response from polling a device code."""
+
+    status: str = Field(..., description="pending | completed | expired | denied")
+    token: str | None = Field(None, description="Finna JWT (only when completed)")
+    user_id: int | None = Field(None, description="User ID (only when completed)")
+    username: str | None = Field(None, description="Username (only when completed)")
+
+
+# ============================================================================
 # Token schemas
 # ============================================================================
 

--- a/backend/app/api/models.py
+++ b/backend/app/api/models.py
@@ -210,9 +210,9 @@ class OIDCDevicePollResponse(BaseModel):
     """Response from polling a device code."""
 
     status: str = Field(..., description="pending | completed | expired | denied")
-    token: str | None = Field(None, description="Finna JWT (only when completed)")
-    user_id: int | None = Field(None, description="User ID (only when completed)")
-    username: str | None = Field(None, description="Username (only when completed)")
+    token: str | None = Field(default=None, description="Finna JWT (only when completed)")
+    user_id: int | None = Field(default=None, description="User ID (only when completed)")
+    username: str | None = Field(default=None, description="Username (only when completed)")
 
 
 # ============================================================================

--- a/backend/app/api/oidc.py
+++ b/backend/app/api/oidc.py
@@ -32,6 +32,10 @@ JWKS_CACHE_TTL = 300  # 5 minutes
 _state_store: dict[str, dict[str, Any]] = {}
 STATE_EXPIRY = 600  # 10 minutes
 
+# Device code flow storage (device_code -> metadata)
+_device_code_store: dict[str, dict[str, Any]] = {}
+DEVICE_CODE_EXPIRY = 600  # 10 minutes
+
 
 class OIDCError(Exception):
     """Base OIDC error."""
@@ -345,6 +349,110 @@ async def verify_id_token(
     return claims
 
 
+async def verify_id_token_no_nonce(
+    id_token: str,
+    provider_metadata: ProviderMetadata,
+    client_id: str,
+) -> dict[str, Any]:
+    """
+    Verify ID token without nonce binding (for device code flow).
+
+    Same security checks as verify_id_token except nonce is skipped,
+    since RFC 8628 device code flow does not provide a nonce.
+
+    Args:
+        id_token: Signed JWT from token_endpoint
+        provider_metadata: From discover_provider()
+        client_id: OIDC client ID
+
+    Returns:
+        Decoded and validated claims dict.
+
+    Raises:
+        OIDCError: If validation fails.
+    """
+    issuer = provider_metadata.get("issuer", "")
+
+    if not issuer:
+        raise OIDCError("Provider metadata missing issuer")
+
+    # Get JWKS
+    jwks = await get_jwks(issuer)
+    keys = jwks.get("keys", [])
+
+    if not keys:
+        raise OIDCError("JWKS has no keys")
+
+    # Decode header to get kid
+    try:
+        header = jwt.get_unverified_header(id_token)
+    except JWTError as e:
+        raise OIDCError(f"Invalid token format: {e}") from e
+
+    kid = header.get("kid")
+    alg = header.get("alg", "")
+
+    # Reject alg:none and HS*
+    if alg == "none" or alg.startswith("HS"):
+        raise OIDCError(f"Insecure algorithm not allowed: {alg}")
+
+    # Find the key
+    key = None
+    for k in keys:
+        if k.get("kid") == kid:
+            key = k
+            break
+
+    if not key:
+        if kid:
+            logger.warning(f"JWKS kid {kid} not found, trying all keys (kid rotation?)")
+        if not keys:
+            raise OIDCError("No keys in JWKS to verify with")
+        for k in keys:
+            k_alg = k.get("alg", "")
+            if k_alg.startswith("RS") or k_alg.startswith("ES"):
+                key = k
+                break
+
+    if not key:
+        raise OIDCError("No suitable key found in JWKS")
+
+    # Verify signature (disable jose's built-in aud check — we do it ourselves below)
+    try:
+        claims = cast(dict[str, Any], jwt.decode(
+            id_token, key, algorithms=[alg],
+            options={"verify_signature": True, "verify_aud": False},
+        ))
+    except JWTError as e:
+        raise OIDCError(f"Signature verification failed: {e}") from e
+
+    # Validate claims
+    now = datetime.now(UTC).timestamp()
+
+    exp = claims.get("exp")
+    if not exp or exp < now:
+        raise OIDCError("ID token expired")
+
+    iat = claims.get("iat")
+    if iat and iat > now + 300:
+        raise OIDCError("ID token iat in future (clock skew > 5 min?)")
+
+    token_iss = claims.get("iss", "")
+    if token_iss != issuer:
+        raise OIDCError(f"Issuer mismatch: {token_iss} != {issuer}")
+
+    aud = claims.get("aud")
+    if isinstance(aud, list):
+        if client_id not in aud:
+            raise OIDCError(f"Client ID {client_id} not in aud: {aud}")
+    else:
+        if aud != client_id:
+            raise OIDCError(f"Audience mismatch: {aud} != {client_id}")
+
+    # No nonce check for device code flow
+    return claims
+
+
 def generate_pkce_pair() -> tuple[str, str]:
     """
     Generate PKCE code_verifier and code_challenge (S256).
@@ -421,3 +529,165 @@ def clear_expired_states() -> None:
         _state_store.pop(s, None)
     if expired:
         logger.info(f"Cleared {len(expired)} expired OIDC states")
+
+
+async def request_device_code(
+    provider_metadata: ProviderMetadata,
+    client_id: str,
+    scopes: list[str] | None = None,
+) -> dict[str, Any]:
+    """
+    Request device authorization from OIDC provider (RFC 8628).
+
+    Args:
+        provider_metadata: From discover_provider()
+        client_id: OIDC client ID
+        scopes: Optional scope list
+
+    Returns:
+        Dict with device_code, user_code, verification_uri, etc.
+
+    Raises:
+        OIDCError: If device authorization endpoint is not supported or request fails.
+    """
+    device_auth_url = provider_metadata.get("device_authorization_endpoint", "")
+
+    if not device_auth_url:
+        raise OIDCError(
+            "Provider does not support device authorization flow "
+            "(device_authorization_endpoint missing from metadata)"
+        )
+
+    payload: dict[str, Any] = {"client_id": client_id}
+    if scopes:
+        payload["scope"] = " ".join(scopes)
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.post(device_auth_url, data=payload)
+            response.raise_for_status()
+            data = cast(dict[str, Any], response.json())
+    except httpx.RequestError as e:
+        raise OIDCError(f"Device authorization request failed: {e}") from e
+    except httpx.HTTPStatusError as e:
+        logger.error(f"Device authorization HTTP error: {e.response.status_code} {e.response.text}")
+        raise OIDCError(f"Device authorization failed: {e.response.status_code}") from e
+
+    # Validate required fields
+    required = {"device_code", "user_code", "verification_uri"}
+    missing = required - set(data.keys())
+    if missing:
+        raise OIDCError(f"Device authorization response missing: {missing}")
+
+    return data
+
+
+async def exchange_device_code(
+    provider_metadata: ProviderMetadata,
+    client_id: str,
+    client_secret: str,
+    device_code: str,
+    interval: int = 5,
+) -> dict[str, Any]:
+    """
+    Exchange device code for tokens (or poll for authorization status).
+
+    Per RFC 8628 §6.1, the response will be:
+    - 200 with tokens (access_token, id_token) when authorization completes
+    - 400 with error: "authorization_pending" if user hasn't completed auth yet
+    - 400 with error: "slow_down" if polling too frequently
+    - 400 with error: "expired_token" if device_code expired
+    - 400 with error: "access_denied" if user denied
+
+    Args:
+        provider_metadata: From discover_provider()
+        client_id: OIDC client ID
+        client_secret: OIDC client secret (may be empty for public clients)
+        device_code: The device code to exchange
+        interval: Minimum seconds between polls
+
+    Returns:
+        Dict with tokens on success, or {"error": "...", "error_description": "..."} on failure.
+
+    Raises:
+        OIDCError: If the token request itself fails (network error, etc.)
+    """
+    token_url = provider_metadata.get("token_endpoint", "")
+
+    if not token_url:
+        raise OIDCError("No token_endpoint in provider metadata")
+
+    payload = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        "client_id": client_id,
+        "device_code": device_code,
+    }
+    if client_secret:
+        payload["client_secret"] = client_secret
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.post(token_url, data=payload)
+
+            # RFC 8628: pending/denied/expired return 400 with error field
+            if response.status_code == 400:
+                data = cast(dict[str, Any], response.json())
+                return data
+
+            response.raise_for_status()
+            return cast(dict[str, Any], response.json())
+    except httpx.RequestError as e:
+        raise OIDCError(f"Device code token exchange request failed: {e}") from e
+
+
+def store_device_code(
+    device_code: str,
+    provider_id: str,
+    client_id: str,
+    client_secret: str,
+    interval: int,
+    expires_in: int,
+) -> None:
+    """
+    Store device code metadata for later token exchange.
+
+    Args:
+        device_code: The device code from the provider
+        provider_id: OIDC provider UUID
+        client_id: OIDC client ID
+        client_secret: OIDC client secret
+        interval: Polling interval from provider
+        expires_in: Seconds until device code expires
+    """
+    _device_code_store[device_code] = {
+        "provider_id": provider_id,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "interval": interval,
+        "expires_at": time.time() + expires_in,
+    }
+
+
+def get_and_consume_device_code(device_code: str) -> dict[str, Any] | None:
+    """
+    Retrieve and consume device code metadata (one-time use for token exchange).
+
+    Returns:
+        Stored metadata dict, or None if not found/expired.
+    """
+    stored = _device_code_store.pop(device_code, None)
+    if stored is None:
+        return None
+    if time.time() > stored.get("expires_at", 0):
+        return None
+    return stored
+
+
+def clear_expired_device_codes() -> None:
+    """Remove expired device code entries."""
+    now = time.time()
+    expired = [dc for dc, v in _device_code_store.items() if v.get("expires_at", 0) < now]
+    for dc in expired:
+        _device_code_store.pop(dc, None)
+    if expired:
+        logger.info(f"Cleared {len(expired)} expired device codes")

--- a/backend/app/api/routes/oidc_device_auth.py
+++ b/backend/app/api/routes/oidc_device_auth.py
@@ -1,0 +1,335 @@
+"""OIDC device authorization routes — RFC 8628 device code flow for CLI login."""
+
+from __future__ import annotations
+
+import logging
+import time
+from threading import Lock
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+
+from utils.encryption import decrypt_config
+
+from .. import auth as api_auth
+from .. import oidc
+from ..db import execute, insert_and_return, query_one
+from ..models import (
+    OIDCDevicePollRequest,
+    OIDCDevicePollResponse,
+    OIDCDeviceStartRequest,
+    OIDCDeviceStartResponse,
+)
+
+logger = logging.getLogger("api.oidc_device_auth")
+
+router = APIRouter()
+
+# Per-IP rate limiting (same pattern as oidc_auth.py)
+_lock = Lock()
+_start_attempts: dict[str, list[float]] = {}
+_poll_attempts: dict[str, list[float]] = {}
+
+
+def _get_client_ip(request: Request) -> str:
+    """Resolve client IP respecting reverse-proxy headers."""
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    real_ip = request.headers.get("X-Real-IP")
+    if real_ip:
+        return real_ip.strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _check_rate_limit(ip: str, store: dict[str, list[float]], max_attempts: int, window: int) -> bool:
+    """Check if ip has exceeded rate limit. Returns True if rate limited."""
+    now = time.monotonic()
+    with _lock:
+        if ip not in store:
+            store[ip] = []
+        store[ip] = [t for t in store[ip] if now - t < window]
+        if len(store[ip]) >= max_attempts:
+            return True
+        store[ip].append(now)
+    return False
+
+
+def _apply_claim_mappings(claims: dict[str, Any], mappings: dict[str, Any]) -> dict[str, Any]:
+    """Apply claim mappings to extract username, email, is_admin from token claims."""
+    result: dict[str, Any] = {}
+
+    # Username claim mapping
+    username_claim = mappings.get("username", "preferred_username")
+    result["username"] = claims.get(username_claim, "")
+
+    # Email claim mapping
+    email_claim = mappings.get("email", "email")
+    result["email"] = claims.get(email_claim, "")
+
+    # Admin rule: check if claim matches value
+    result["is_admin"] = False
+    admin_rule = mappings.get("is_admin", {})
+    if isinstance(admin_rule, dict):
+        rule_claim = admin_rule.get("claim")
+        rule_match = admin_rule.get("match")
+        if rule_claim and rule_match:
+            claim_value = claims.get(rule_claim)
+            if isinstance(claim_value, list):
+                result["is_admin"] = rule_match in claim_value
+            elif isinstance(claim_value, str):
+                result["is_admin"] = claim_value == rule_match
+
+    return result
+
+
+@router.post("/auth/oidc/device")
+async def oidc_device_start(
+    req: OIDCDeviceStartRequest,
+    request: Request,
+) -> OIDCDeviceStartResponse:
+    """Initiate OIDC device authorization flow for CLI login (RFC 8628).
+
+    Returns a device code, user code, and verification URL. The CLI displays
+    the URL and code, then polls POST /auth/oidc/device/callback until the
+    user completes authentication in their browser.
+    """
+    ip = _get_client_ip(request)
+    if _check_rate_limit(ip, _start_attempts, 5, 60):
+        raise HTTPException(status_code=429, detail="Too many login attempts. Try again later.")
+
+    # Get provider
+    provider = query_one(
+        "SELECT id, config FROM auth_providers WHERE id = %s AND enabled = true AND kind = 'oidc'",
+        (req.provider_id,),
+    )
+    if not provider:
+        raise HTTPException(status_code=404, detail="Provider not found or disabled")
+
+    config = decrypt_config(provider["config"])
+    client_id = config.get("client_id", "")
+    client_secret = config.get("client_secret", "")
+    issuer = config.get("issuer", "")
+
+    if not client_id:
+        raise HTTPException(status_code=400, detail="Provider missing client_id")
+
+    try:
+        # Discover metadata (cached)
+        metadata = await oidc.discover_provider(issuer)
+
+        # Check if device flow is supported
+        if not metadata.get("device_authorization_endpoint"):
+            raise HTTPException(
+                status_code=400,
+                detail="Provider does not support device authorization flow",
+            )
+
+        # Request device code from provider
+        device_data = await oidc.request_device_code(
+            metadata,
+            client_id=client_id,
+            scopes=config.get("scopes", ["openid", "profile", "email"]),
+        )
+
+        device_code = device_data["device_code"]
+        user_code = device_data["user_code"]
+        verification_uri = device_data["verification_uri"]
+        verification_uri_complete = device_data.get("verification_uri_complete")
+        expires_in = device_data.get("expires_in", 600)
+        interval = device_data.get("interval", 5)
+
+        # Store device code metadata for later token exchange
+        oidc.store_device_code(
+            device_code=device_code,
+            provider_id=str(provider["id"]),
+            client_id=client_id,
+            client_secret=client_secret,
+            interval=interval,
+            expires_in=expires_in,
+        )
+
+        return OIDCDeviceStartResponse(
+            device_code=device_code,
+            user_code=user_code,
+            verification_uri=verification_uri,
+            verification_uri_complete=verification_uri_complete,
+            expires_in=expires_in,
+            interval=interval,
+        )
+
+    except oidc.OIDCError as e:
+        logger.error(f"OIDC device auth start error: {e}")
+        raise HTTPException(status_code=400, detail=f"Login setup failed: {str(e)}") from e
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Unexpected error during device auth start: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post("/auth/oidc/device/callback")
+async def oidc_device_callback(
+    req: OIDCDevicePollRequest,
+    request: Request,
+) -> OIDCDevicePollResponse:
+    """Poll/exchange a device code for tokens.
+
+    The CLI should call this endpoint repeatedly (respecting the interval from
+    the start response) until status is "completed", "expired", or "denied".
+    """
+    ip = _get_client_ip(request)
+    if _check_rate_limit(ip, _poll_attempts, 30, 60):
+        raise HTTPException(status_code=429, detail="Too many polling attempts.")
+
+    # Retrieve stored device code metadata
+    stored = oidc.get_and_consume_device_code(req.device_code)
+    if not stored:
+        raise HTTPException(status_code=404, detail="Invalid or expired device code")
+
+    provider_id = stored["provider_id"]
+    client_id = stored["client_id"]
+    client_secret = stored["client_secret"]
+
+    # Get provider
+    provider = query_one(
+        "SELECT id, config FROM auth_providers WHERE id = %s AND enabled = true AND kind = 'oidc'",
+        (provider_id,),
+    )
+    if not provider:
+        raise HTTPException(status_code=404, detail="Provider not found or disabled")
+
+    config = decrypt_config(provider["config"])
+    issuer = config.get("issuer", "")
+
+    try:
+        # Discover metadata (cached)
+        metadata = await oidc.discover_provider(issuer)
+
+        # Exchange device code for tokens
+        token_data = await oidc.exchange_device_code(
+            metadata,
+            client_id=client_id,
+            client_secret=client_secret,
+            device_code=req.device_code,
+            interval=stored.get("interval", 5),
+        )
+
+        # Handle error responses from the provider
+        if "error" in token_data:
+            error = token_data["error"]
+            # Re-store if still pending (so the CLI can poll again)
+            if error == "authorization_pending":
+                oidc.store_device_code(
+                    device_code=req.device_code,
+                    provider_id=provider_id,
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    interval=stored.get("interval", 5),
+                    expires_in=int(token_data.get("expires_in", 300)),
+                )
+                return OIDCDevicePollResponse(status="pending")
+            elif error == "slow_down":
+                oidc.store_device_code(
+                    device_code=req.device_code,
+                    provider_id=provider_id,
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    interval=stored.get("interval", 5),
+                    expires_in=int(token_data.get("expires_in", 300)),
+                )
+                return OIDCDevicePollResponse(status="pending")
+            elif error in ("expired_token", "access_denied"):
+                return OIDCDevicePollResponse(status="expired" if error == "expired_token" else "denied")
+            else:
+                raise oidc.OIDCError(f"Provider error: {error}")
+
+        # Success — extract tokens
+        id_token = token_data.get("id_token", "")
+        if not id_token:
+            raise oidc.OIDCError("No id_token in device code token response")
+
+        # We don't have a nonce from device code flow (RFC 8628 §11),
+        # so use a sentinel. The nonce check in verify_id_token is not
+        # strictly required for device flow since the code is the secret.
+        # We verify without nonce binding.
+        claims = await oidc.verify_id_token_no_nonce(id_token, metadata, client_id)
+
+        # Apply claim mappings
+        mappings = config.get("claim_mappings", {})
+        mapped = _apply_claim_mappings(claims, mappings)
+
+        username = mapped.get("username", "")
+        email = mapped.get("email", "")
+        is_admin = mapped.get("is_admin", False)
+
+        if not username or not email:
+            raise HTTPException(status_code=400, detail="Missing required claims (username, email)")
+
+        # Email domain filter
+        allowed_domains = config.get("allowed_email_domains", [])
+        if allowed_domains:
+            email_domain = email.split("@")[1] if "@" in email else ""
+            if email_domain not in allowed_domains:
+                raise HTTPException(status_code=403, detail="Email domain not allowed")
+
+        # Look up user by (provider_id, oidc_subject)
+        oidc_subject = claims.get("sub", "")
+        user = query_one(
+            "SELECT id, username, is_admin FROM auth_users WHERE oidc_provider_id = %s AND oidc_subject = %s",
+            (provider_id, oidc_subject),
+        )
+
+        if not user:
+            # Auto-provision if enabled
+            if not config.get("auto_provision", False):
+                raise HTTPException(status_code=403, detail="User not provisioned. Contact admin.")
+
+            # Create new user
+            db_id = insert_and_return(
+                """
+                INSERT INTO auth_users
+                    (username, email, oidc_provider_id, oidc_subject, oidc_claims, is_admin, is_active)
+                VALUES (%s, %s, %s, %s, %s, %s, true)
+                RETURNING id
+                """,
+                (username, email, provider_id, oidc_subject, claims, is_admin),
+            )
+            user = {"id": int(db_id), "username": username, "is_admin": is_admin}
+        else:
+            # Update is_admin based on current claim mapping
+            execute(
+                "UPDATE auth_users SET is_admin = %s, oidc_claims = %s WHERE id = %s",
+                (is_admin, claims, user["id"]),
+            )
+            user["is_admin"] = is_admin
+
+        # Issue Finna JWT
+        token = api_auth.create_access_token(
+            {"sub": user["username"], "is_admin": user.get("is_admin", False)}
+        )
+
+        return OIDCDevicePollResponse(
+            status="completed",
+            token=token,
+            user_id=user["id"],
+            username=user["username"],
+        )
+
+    except oidc.OIDCError as e:
+        logger.error(f"OIDC device code exchange error: {e}")
+        # Re-store so CLI can retry
+        oidc.store_device_code(
+            device_code=req.device_code,
+            provider_id=provider_id,
+            client_id=client_id,
+            client_secret=client_secret,
+            interval=stored.get("interval", 5),
+            expires_in=300,
+        )
+        raise HTTPException(status_code=400, detail=f"Token exchange failed: {str(e)}") from e
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Unexpected error during device code exchange: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/tests/test_oidc_device_auth.py
+++ b/tests/test_oidc_device_auth.py
@@ -1,0 +1,544 @@
+"""Integration tests for OIDC device authorization flow (RFC 8628).
+
+All DB calls are mocked — no Postgres required.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from jose import jwt
+
+from backend.app.api import oidc
+from backend.app.api.main import app
+from utils.encryption import encrypt_config
+
+
+@pytest.fixture
+def client():
+    """FastAPI test client."""
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def rsa_keypair():
+    """Ephemeral RSA keypair for signing test ID tokens."""
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+
+    e = public_key.public_numbers().e
+    n = public_key.public_numbers().n
+
+    jwk = {
+        "kty": "RSA",
+        "kid": "test-key-1",
+        "use": "sig",
+        "alg": "RS256",
+        "n": base64.urlsafe_b64encode(n.to_bytes(256, "big")).decode().rstrip("="),
+        "e": base64.urlsafe_b64encode(e.to_bytes(3, "big")).decode().rstrip("="),
+    }
+
+    return {
+        "private_key": private_key,
+        "jwk": jwk,
+    }
+
+
+def _make_provider_config():
+    """Build OIDC provider config dict."""
+    return {
+        "issuer": "https://keycloak.example.com/realms/test",
+        "client_id": "test-app",
+        "client_secret": "test-secret",
+        "redirect_uri": "http://localhost:5173/auth/oidc/callback",
+        "scopes": ["openid", "profile", "email"],
+        "claim_mappings": {
+            "username": "preferred_username",
+            "email": "email",
+            "is_admin": {"claim": "groups", "match": "finna-admins"},
+        },
+        "auto_provision": True,
+        "allowed_email_domains": ["example.com", "acme.co"],
+    }
+
+
+def _make_provider_row(config=None):
+    """Build a mock DB row for an OIDC provider."""
+    cfg = config or _make_provider_config()
+    return {
+        "id": str(uuid.uuid4()),
+        "config": encrypt_config(cfg),
+    }
+
+
+def _mock_query_one_factory(provider_row):
+    """Return a mock query_one that returns provider for provider queries, None for user queries."""
+    def mock_query_one(sql, params=None):
+        if "auth_providers" in sql:
+            return provider_row
+        return None
+    return mock_query_one
+
+
+async def _mock_get_jwks(issuer):
+    """Return JWKS containing the test RSA key."""
+    return {"keys": [rsa_keypair_for_mock["jwk"]]}
+
+
+rsa_keypair_for_mock: dict = {}
+
+
+def _mock_get_jwks_factory(keypair):
+    """Return a mock get_jwks that returns the test RSA key."""
+    async def mock_get_jwks(issuer):
+        return {"keys": [keypair["jwk"]]}
+    return mock_get_jwks
+
+
+def sign_test_id_token(rsa_keypair, claims: dict) -> str:
+    """Sign test ID token."""
+    from cryptography.hazmat.primitives import serialization
+
+    private_key = rsa_keypair["private_key"]
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return jwt.encode(claims, pem, algorithm="RS256", headers={"kid": "test-key-1"})
+
+
+DEVICE_AUTH_METADATA = {
+    "issuer": "https://keycloak.example.com/realms/test",
+    "authorization_endpoint": "https://keycloak.example.com/realms/test/protocol/openid-connect/auth",
+    "token_endpoint": "https://keycloak.example.com/realms/test/protocol/openid-connect/token",
+    "jwks_uri": "https://keycloak.example.com/realms/test/protocol/openid-connect/certs",
+    "device_authorization_endpoint": "https://keycloak.example.com/realms/test/protocol/openid-connect/device",
+}
+
+
+def test_device_start_returns_required_fields(client, rsa_keypair):
+    """Device start returns device_code, user_code, verification_uri."""
+    oidc._discovery_cache.clear()
+    oidc._device_code_store.clear()
+
+    provider_row = _make_provider_row()
+
+    device_auth_response = {
+        "device_code": "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNh",
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://keycloak.example.com/device",
+        "verification_uri_complete": "https://keycloak.example.com/device?user_code=WDJB-MJHT",
+        "expires_in": 600,
+        "interval": 5,
+    }
+
+    with patch("backend.app.api.routes.oidc_device_auth.query_one", return_value=provider_row), \
+         patch("backend.app.api.oidc.httpx.AsyncClient") as mock_client_ctx:
+
+        mock_client = AsyncMock()
+        mock_client_ctx.return_value.__aenter__.return_value = mock_client
+
+        disc_resp = MagicMock()
+        disc_resp.status_code = 200
+        disc_resp.json.return_value = DEVICE_AUTH_METADATA
+        mock_client.get.return_value = disc_resp
+
+        dev_resp = MagicMock()
+        dev_resp.status_code = 200
+        dev_resp.json.return_value = device_auth_response
+        mock_client.post.return_value = dev_resp
+
+        response = client.post(
+            "/api/v1/auth/oidc/device",
+            json={"provider_id": provider_row["id"]},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["device_code"] == "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNh"
+    assert data["user_code"] == "WDJB-MJHT"
+    assert data["verification_uri"] == "https://keycloak.example.com/device"
+    assert data["verification_uri_complete"] == "https://keycloak.example.com/device?user_code=WDJB-MJHT"
+    assert data["expires_in"] == 600
+    assert data["interval"] == 5
+
+    assert "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNh" in oidc._device_code_store
+
+
+def test_device_start_provider_not_found(client):
+    """Device start with non-existent provider returns 404."""
+    with patch("backend.app.api.routes.oidc_device_auth.query_one", return_value=None):
+        response = client.post(
+            "/api/v1/auth/oidc/device",
+            json={"provider_id": str(uuid.uuid4())},
+        )
+    assert response.status_code == 404
+
+
+def test_device_start_no_device_endpoint(client):
+    """Device start returns 400 when provider lacks device_authorization_endpoint."""
+    oidc._discovery_cache.clear()
+    provider_row = _make_provider_row()
+
+    metadata_without_device = {
+        "issuer": "https://keycloak.example.com/realms/test",
+        "authorization_endpoint": "https://keycloak.example.com/realms/test/protocol/openid-connect/auth",
+        "token_endpoint": "https://keycloak.example.com/realms/test/protocol/openid-connect/token",
+        "jwks_uri": "https://keycloak.example.com/realms/test/protocol/openid-connect/certs",
+    }
+
+    with patch("backend.app.api.routes.oidc_device_auth.query_one", return_value=provider_row), \
+         patch("backend.app.api.oidc.httpx.AsyncClient") as mock_client_ctx:
+
+        mock_client = AsyncMock()
+        mock_client_ctx.return_value.__aenter__.return_value = mock_client
+
+        disc_resp = MagicMock()
+        disc_resp.status_code = 200
+        disc_resp.json.return_value = metadata_without_device
+        mock_client.get.return_value = disc_resp
+
+        response = client.post(
+            "/api/v1/auth/oidc/device",
+            json={"provider_id": provider_row["id"]},
+        )
+
+    assert response.status_code == 400
+    assert "device authorization" in response.json()["detail"].lower()
+
+
+def test_device_poll_pending(client):
+    """Poll returns pending when user hasn't completed auth."""
+    oidc._discovery_cache.clear()
+    oidc._device_code_store.clear()
+
+    device_code = "test-pending-device-code"
+    provider_row = _make_provider_row()
+
+    oidc.store_device_code(
+        device_code=device_code,
+        provider_id=provider_row["id"],
+        client_id="test-app",
+        client_secret="test-secret",
+        interval=5,
+        expires_in=600,
+    )
+
+    with patch("backend.app.api.routes.oidc_device_auth.query_one", return_value=provider_row), \
+         patch("backend.app.api.oidc.httpx.AsyncClient") as mock_client_ctx:
+
+        mock_client = AsyncMock()
+        mock_client_ctx.return_value.__aenter__.return_value = mock_client
+
+        disc_resp = MagicMock()
+        disc_resp.json.return_value = DEVICE_AUTH_METADATA
+        mock_client.get.return_value = disc_resp
+
+        pending_resp = MagicMock()
+        pending_resp.status_code = 400
+        pending_resp.json.return_value = {
+            "error": "authorization_pending",
+            "error_description": "The authorization request is still pending",
+        }
+        mock_client.post.return_value = pending_resp
+
+        response = client.post(
+            "/api/v1/auth/oidc/device/callback",
+            json={"device_code": device_code},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "pending"
+    assert response.json()["token"] is None
+
+    assert device_code in oidc._device_code_store
+
+
+def test_device_poll_completed(client, rsa_keypair):
+    """Poll returns JWT when user completes auth."""
+    oidc._discovery_cache.clear()
+    oidc._device_code_store.clear()
+    oidc._jwks_cache.clear()
+
+    device_code = "test-completed-device-code"
+    provider_row = _make_provider_row()
+
+    oidc.store_device_code(
+        device_code=device_code,
+        provider_id=provider_row["id"],
+        client_id="test-app",
+        client_secret="test-secret",
+        interval=5,
+        expires_in=600,
+    )
+
+    now = int(time.time())
+    id_token_claims = {
+        "iss": "https://keycloak.example.com/realms/test",
+        "sub": "device_user_12345",
+        "aud": "test-app",
+        "exp": now + 3600,
+        "iat": now,
+        "preferred_username": "deviceuser",
+        "email": "deviceuser@example.com",
+        "groups": ["users"],
+    }
+    id_token = sign_test_id_token(rsa_keypair, id_token_claims)
+
+    def mock_insert_and_return(sql, params=None):
+        return 42
+
+    def mock_execute(sql, params=None):
+        pass
+
+    with patch("backend.app.api.routes.oidc_device_auth.query_one",
+               side_effect=_mock_query_one_factory(provider_row)), \
+         patch("backend.app.api.routes.oidc_device_auth.insert_and_return",
+               side_effect=mock_insert_and_return), \
+         patch("backend.app.api.routes.oidc_device_auth.execute",
+               side_effect=mock_execute), \
+         patch("backend.app.api.oidc.get_jwks",
+               side_effect=_mock_get_jwks_factory(rsa_keypair)), \
+         patch("backend.app.api.oidc.httpx.AsyncClient") as mock_client_ctx:
+
+        mock_client = AsyncMock()
+        mock_client_ctx.return_value.__aenter__.return_value = mock_client
+
+        disc_resp = MagicMock()
+        disc_resp.json.return_value = DEVICE_AUTH_METADATA
+        mock_client.get.return_value = disc_resp
+
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {
+            "access_token": "access_token_123",
+            "id_token": id_token,
+            "token_type": "Bearer",
+        }
+        mock_client.post.return_value = token_resp
+
+        response = client.post(
+            "/api/v1/auth/oidc/device/callback",
+            json={"device_code": device_code},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "completed"
+    assert "token" in data
+    assert data["username"] == "deviceuser"
+    assert data["user_id"] == 42
+
+    assert device_code not in oidc._device_code_store
+
+    from backend.app.api.auth import decode_token
+    decoded = decode_token(data["token"])
+    assert decoded["sub"] == "deviceuser"
+    assert decoded["is_admin"] is False
+
+
+def test_device_poll_expired(client):
+    """Poll returns 404 when device code has expired."""
+    oidc._device_code_store.clear()
+
+    device_code = "test-expired-device-code"
+    provider_row = _make_provider_row()
+
+    oidc._device_code_store[device_code] = {
+        "provider_id": provider_row["id"],
+        "client_id": "test-app",
+        "client_secret": "test-secret",
+        "interval": 5,
+        "expires_at": time.time() - 10,
+    }
+
+    response = client.post(
+        "/api/v1/auth/oidc/device/callback",
+        json={"device_code": device_code},
+    )
+
+    assert response.status_code == 404
+
+
+def test_device_poll_invalid_code(client):
+    """Poll returns 404 for unknown device code."""
+    response = client.post(
+        "/api/v1/auth/oidc/device/callback",
+        json={"device_code": "completely-unknown-code"},
+    )
+    assert response.status_code == 404
+
+
+def test_device_poll_access_denied(client):
+    """Poll returns denied when user denies authorization."""
+    oidc._discovery_cache.clear()
+    oidc._device_code_store.clear()
+
+    device_code = "test-denied-device-code"
+    provider_row = _make_provider_row()
+
+    oidc.store_device_code(
+        device_code=device_code,
+        provider_id=provider_row["id"],
+        client_id="test-app",
+        client_secret="test-secret",
+        interval=5,
+        expires_in=600,
+    )
+
+    with patch("backend.app.api.routes.oidc_device_auth.query_one", return_value=provider_row), \
+         patch("backend.app.api.oidc.httpx.AsyncClient") as mock_client_ctx:
+
+        mock_client = AsyncMock()
+        mock_client_ctx.return_value.__aenter__.return_value = mock_client
+
+        disc_resp = MagicMock()
+        disc_resp.json.return_value = DEVICE_AUTH_METADATA
+        mock_client.get.return_value = disc_resp
+
+        denied_resp = MagicMock()
+        denied_resp.status_code = 400
+        denied_resp.json.return_value = {
+            "error": "access_denied",
+            "error_description": "The user denied the authorization",
+        }
+        mock_client.post.return_value = denied_resp
+
+        response = client.post(
+            "/api/v1/auth/oidc/device/callback",
+            json={"device_code": device_code},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "denied"
+
+
+def test_device_poll_email_domain_filter(client, rsa_keypair):
+    """Poll rejects user with non-allowed email domain."""
+    oidc._discovery_cache.clear()
+    oidc._device_code_store.clear()
+    oidc._jwks_cache.clear()
+
+    device_code = "test-domain-filter-device-code"
+    provider_row = _make_provider_row()
+
+    oidc.store_device_code(
+        device_code=device_code,
+        provider_id=provider_row["id"],
+        client_id="test-app",
+        client_secret="test-secret",
+        interval=5,
+        expires_in=600,
+    )
+
+    now = int(time.time())
+    id_token_claims = {
+        "iss": "https://keycloak.example.com/realms/test",
+        "sub": "user_bad_domain",
+        "aud": "test-app",
+        "exp": now + 3600,
+        "iat": now,
+        "preferred_username": "baduser",
+        "email": "baduser@unauthorized.com",
+        "groups": ["users"],
+    }
+    id_token = sign_test_id_token(rsa_keypair, id_token_claims)
+
+    with patch("backend.app.api.routes.oidc_device_auth.query_one",
+               side_effect=_mock_query_one_factory(provider_row)), \
+         patch("backend.app.api.oidc.get_jwks",
+               side_effect=_mock_get_jwks_factory(rsa_keypair)), \
+         patch("backend.app.api.oidc.httpx.AsyncClient") as mock_client_ctx:
+
+        mock_client = AsyncMock()
+        mock_client_ctx.return_value.__aenter__.return_value = mock_client
+
+        disc_resp = MagicMock()
+        disc_resp.json.return_value = DEVICE_AUTH_METADATA
+        mock_client.get.return_value = disc_resp
+
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {
+            "access_token": "access_token_456",
+            "id_token": id_token,
+            "token_type": "Bearer",
+        }
+        mock_client.post.return_value = token_resp
+
+        response = client.post(
+            "/api/v1/auth/oidc/device/callback",
+            json={"device_code": device_code},
+        )
+
+    assert response.status_code == 403
+    assert "domain" in response.json()["detail"].lower()
+
+
+def test_device_poll_missing_claims(client, rsa_keypair):
+    """Poll rejects when required claims are missing from ID token."""
+    oidc._discovery_cache.clear()
+    oidc._device_code_store.clear()
+    oidc._jwks_cache.clear()
+
+    device_code = "test-missing-claims-device-code"
+    provider_row = _make_provider_row()
+
+    oidc.store_device_code(
+        device_code=device_code,
+        provider_id=provider_row["id"],
+        client_id="test-app",
+        client_secret="test-secret",
+        interval=5,
+        expires_in=600,
+    )
+
+    now = int(time.time())
+    id_token_claims = {
+        "iss": "https://keycloak.example.com/realms/test",
+        "sub": "user_no_email",
+        "aud": "test-app",
+        "exp": now + 3600,
+        "iat": now,
+        "preferred_username": "noemailuser",
+    }
+    id_token = sign_test_id_token(rsa_keypair, id_token_claims)
+
+    with patch("backend.app.api.routes.oidc_device_auth.query_one",
+               side_effect=_mock_query_one_factory(provider_row)), \
+         patch("backend.app.api.oidc.get_jwks",
+               side_effect=_mock_get_jwks_factory(rsa_keypair)), \
+         patch("backend.app.api.oidc.httpx.AsyncClient") as mock_client_ctx:
+
+        mock_client = AsyncMock()
+        mock_client_ctx.return_value.__aenter__.return_value = mock_client
+
+        disc_resp = MagicMock()
+        disc_resp.json.return_value = DEVICE_AUTH_METADATA
+        mock_client.get.return_value = disc_resp
+
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {
+            "access_token": "access_token_789",
+            "id_token": id_token,
+            "token_type": "Bearer",
+        }
+        mock_client.post.return_value = token_resp
+
+        response = client.post(
+            "/api/v1/auth/oidc/device/callback",
+            json={"device_code": device_code},
+        )
+
+    assert response.status_code == 400
+    assert "claims" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Adds OIDC Device Authorization Grant (RFC 8628) endpoints for CLI login.

## Endpoints

- **POST /auth/oidc/device** — Initiate device code flow. Returns device_code, user_code, verification_uri, verification_uri_complete.
- **POST /auth/oidc/device/callback** — Poll/exchange device code. Returns status (pending/completed/denied/expired) and JWT on completion.

## Features

- OIDC discovery and JWKS caching (shared with existing login flow)
- Device code in-memory store with configurable expiry
- Rate limiting: 5 starts/min, 30 polls/min per IP
- Email domain filtering from provider config
- Auto-provision users on first login
- Admin claim mapping from provider config
- verify_id_token_no_nonce for device flow (RFC 8628 §11)

## Tests

10 integration tests covering all device flow scenarios (no Postgres required — all DB calls mocked):

1. Start flow returns required fields
2. Start with non-existent provider returns 404
3. Start without device_authorization_endpoint returns 400
4. Poll with pending status
5. Poll with completed status (full JWT verification)
6. Poll with expired device code
7. Poll with invalid device code
8. Poll with access denied
9. Email domain filter rejection
10. Missing required claims rejection

## Bug fix

Fixed verify_id_token_no_nonce to pass verify_aud=False to jose jwt.decode — the existing code let jose validate audience internally, causing false failures when audience matched but jose internal check disagreed.